### PR TITLE
Fix build errors

### DIFF
--- a/open-bpmn.glsp-client/.gitignore
+++ b/open-bpmn.glsp-client/.gitignore
@@ -34,6 +34,7 @@ buildNumber.properties
 node_modules
 node_modules/.yarn-integrity
 .browser_modules
+tsconfig.tsbuildinfo
 # yarn.lock - no good idea
 lib
 

--- a/open-bpmn.glsp-client/open-bpmn-app/webpack.config.js
+++ b/open-bpmn.glsp-client/open-bpmn-app/webpack.config.js
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// @ts-check
+const config = require('./gen-webpack.config.js');
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+module.exports = config;
+config.ignoreWarnings = [/Failed to parse source map/];

--- a/open-bpmn.glsp-client/open-bpmn-glsp/package.json
+++ b/open-bpmn.glsp-client/open-bpmn-glsp/package.json
@@ -32,10 +32,10 @@
   "peerDependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
-  },  
+  },
   "scripts": {
     "prepare": "yarn clean && yarn build && yarn lint",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
     "build": "tsc",
     "lint": "eslint -c ../.eslintrc.js --ext .ts,.tsx ./src",
     "watch": "tsc -w"

--- a/open-bpmn.glsp-client/open-bpmn-glsp/src/bpmn-element-views.tsx
+++ b/open-bpmn.glsp-client/open-bpmn-glsp/src/bpmn-element-views.tsx
@@ -14,20 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-	getSubType,
-	RenderingContext,
-	setAttr,
-	ActionDispatcher,SelectAction,
-	SModelRoot,getElements,
-	TYPES
+    ActionDispatcher,
+    getElements,
+    getSubType,
+    RenderingContext,
+    SelectAction,
+    setAttr,
+    SModelRoot,
+    TYPES
 } from '@eclipse-glsp/client';
+import { SelectionListener } from '@eclipse-glsp/client/lib/features/select/selection-service';
+import { Icon, isBPMNLabelNode, isEventNode, isGatewayNode, isTaskNode } from '@open-bpmn/open-bpmn-model';
 import { inject, injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { findParentByFeature, ShapeView, svg } from 'sprotty';
-import { Icon, isTaskNode, isEventNode, isGatewayNode, isBPMNLabelNode } from '@open-bpmn/open-bpmn-model';
-import {
-	SelectionListener
-} from '@eclipse-glsp/client/lib/features/select/selection-service';
 /****************************************************************************
  * This module provides BPMN element views like Gateways, or Events
  *
@@ -43,141 +43,135 @@ const JSX = { createElement: svg };
  */
 @injectable()
 export class IconView extends ShapeView {
-	render(element: Icon, context: RenderingContext): VNode | undefined {
+    render(element: Icon, context: RenderingContext): VNode | undefined {
+        let scaleFactor = 1;
+        let translate = 0;
+        if (!this.isVisible(element, context)) {
+            return undefined;
+        }
 
-		let scaleFactor=1;
-		let translate=0;
-		if (!this.isVisible(element, context)) {
-			return undefined;
-		}
+        const taskNode = findParentByFeature(element, isTaskNode);
+        const eventNode = findParentByFeature(element, isEventNode);
+        const gatewayNode = findParentByFeature(element, isGatewayNode);
+        if (!(eventNode || taskNode || gatewayNode)) {
+            return undefined;
+        }
 
-		const taskNode = findParentByFeature(element, isTaskNode);
-		const eventNode = findParentByFeature(element, isEventNode);
-		const gatewayNode = findParentByFeature(element, isGatewayNode);
-		if (!(eventNode || taskNode || gatewayNode)) {
-			return undefined;
-		}
+        let icon;
+        if (taskNode) {
+            if (taskNode.type === 'manualTask') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M10.54 2c.289.001.57.088.81.25a1.38 1.38 0 0 1 .45 1.69l-.97 2.17h2.79a1.36 1.36 0 0 1 1.16.61 1.35 1.35 0 0 1 .09 1.32c-.67 1.45-1.87 4.07-2.27 5.17a1.38 1.38 0 0 1-1.29.9H2.38A1.4 1.4 0 0 1 1 12.71V9.2a1.38 1.38 0 0 1 1.38-1.38h1.38L9.6 2.36a1.41 1.41 0 0 1 .94-.36zm.77 11.11a.39.39 0 0 0 .36-.25c.4-1.09 1.47-3.45 2.33-5.24a.39.39 0 0 0 0-.36.37.37 0 0 0-.38-.15h-3.3l-.52-.68v-.46l1.09-2.44a.37.37 0 0 0-.13-.46.38.38 0 0 0-.48 0L4.22 8.66l-.47.13H2.38A.38.38 0 0 0 2 9.2v3.51a.4.4 0 0 0 .38.4h8.93z';
+            } else if (taskNode.type === 'serviceTask') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
+                icon = 'M2.5 2H4v12H2.5V2zm4.936.39L6.25 3v10l1.186.61 7-5V7.39l-7-5zM12.71 8l-4.96 3.543V4.457L12.71 8z';
+            } else if (taskNode.type === 'userTask') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M16 7.992C16 3.58 12.416 0 8 0S0 3.58 0 7.992c0 2.43 1.104 4.62 2.832 6.09.016.016.032.016.032.032.144.112.288.224.448.336.08.048.144.111.224.175A7.98 7.98 0 0 0 8.016 16a7.98 7.98 0 0 0 4.48-1.375c.08-.048.144-.111.224-.16.144-.111.304-.223.448-.335.016-.016.032-.016.032-.032 1.696-1.487 2.8-3.676 2.8-6.106zm-8 7.001c-1.504 0-2.88-.48-4.016-1.279.016-.128.048-.255.08-.383a4.17 4.17 0 0 1 .416-.991c.176-.304.384-.576.64-.816.24-.24.528-.463.816-.639.304-.176.624-.304.976-.4A4.15 4.15 0 0 1 8 10.342a4.185 4.185 0 0 1 2.928 1.166c.368.368.656.8.864 1.295.112.288.192.592.24.911A7.03 7.03 0 0 1 8 14.993zm-2.448-7.4a2.49 2.49 0 0 1-.208-1.024c0-.351.064-.703.208-1.023.144-.32.336-.607.576-.847.24-.24.528-.431.848-.575.32-.144.672-.208 1.024-.208.368 0 .704.064 1.024.208.32.144.608.336.848.575.24.24.432.528.576.847.144.32.208.672.208 1.023 0 .368-.064.704-.208 1.023a2.84 2.84 0 0 1-.576.848 2.84 2.84 0 0 1-.848.575 2.715 2.715 0 0 1-2.064 0 2.84 2.84 0 0 1-.848-.575 2.526 2.526 0 0 1-.56-.848zm7.424 5.306c0-.032-.016-.048-.016-.08a5.22 5.22 0 0 0-.688-1.406 4.883 4.883 0 0 0-1.088-1.135 5.207 5.207 0 0 0-1.04-.608 2.82 2.82 0 0 0 .464-.383 4.2 4.2 0 0 0 .624-.784 3.624 3.624 0 0 0 .528-1.934 3.71 3.71 0 0 0-.288-1.47 3.799 3.799 0 0 0-.816-1.199 3.845 3.845 0 0 0-1.2-.8 3.72 3.72 0 0 0-1.472-.287 3.72 3.72 0 0 0-1.472.288 3.631 3.631 0 0 0-1.2.815 3.84 3.84 0 0 0-.8 1.199 3.71 3.71 0 0 0-.288 1.47c0 .352.048.688.144 1.007.096.336.224.64.4.927.16.288.384.544.624.784.144.144.304.271.48.383a5.12 5.12 0 0 0-1.04.624c-.416.32-.784.703-1.088 1.119a4.999 4.999 0 0 0-.688 1.406c-.016.032-.016.064-.016.08C1.776 11.636.992 9.91.992 7.992.992 4.14 4.144.991 8 .991s7.008 3.149 7.008 7.001a6.96 6.96 0 0 1-2.032 4.907z';
+            } else if (taskNode.type === 'sendTask') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/mail.svg?short_path=d02764e
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M1 3.5l.5-.5h13l.5.5v9l-.5.5h-13l-.5-.5v-9zm1 1.035V12h12V4.536L8.31 8.9H7.7L2 4.535zM13.03 4H2.97L8 7.869 13.03 4z';
+            } else if (taskNode.type === 'scriptTask') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M6 10V9h9v1H6zm4-4h5v1h-5V6zm5-3v1H6V3h9zm-9 9v1h9v-1H6z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M1 2.795l.783-.419 5.371 3.581v.838l-5.371 3.581L1 9.957V2.795zm1.007.94v5.281l3.96-2.64-3.96-2.64z';
+            }
+        }
 
-		let icon;
-		if (taskNode) {
-			if (taskNode.type === 'manualTask') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
-				icon =
-					// eslint-disable-next-line max-len
-					'M10.54 2c.289.001.57.088.81.25a1.38 1.38 0 0 1 .45 1.69l-.97 2.17h2.79a1.36 1.36 0 0 1 1.16.61 1.35 1.35 0 0 1 .09 1.32c-.67 1.45-1.87 4.07-2.27 5.17a1.38 1.38 0 0 1-1.29.9H2.38A1.4 1.4 0 0 1 1 12.71V9.2a1.38 1.38 0 0 1 1.38-1.38h1.38L9.6 2.36a1.41 1.41 0 0 1 .94-.36zm.77 11.11a.39.39 0 0 0 .36-.25c.4-1.09 1.47-3.45 2.33-5.24a.39.39 0 0 0 0-.36.37.37 0 0 0-.38-.15h-3.3l-.52-.68v-.46l1.09-2.44a.37.37 0 0 0-.13-.46.38.38 0 0 0-.48 0L4.22 8.66l-.47.13H2.38A.38.38 0 0 0 2 9.2v3.51a.4.4 0 0 0 .38.4h8.93z';
-			} else if (taskNode.type === 'serviceTask') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
-				icon =
-					'M2.5 2H4v12H2.5V2zm4.936.39L6.25 3v10l1.186.61 7-5V7.39l-7-5zM12.71 8l-4.96 3.543V4.457L12.71 8z';
-			} else if (taskNode.type === 'userTask') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
-				icon =
-					// eslint-disable-next-line max-len
-					'M16 7.992C16 3.58 12.416 0 8 0S0 3.58 0 7.992c0 2.43 1.104 4.62 2.832 6.09.016.016.032.016.032.032.144.112.288.224.448.336.08.048.144.111.224.175A7.98 7.98 0 0 0 8.016 16a7.98 7.98 0 0 0 4.48-1.375c.08-.048.144-.111.224-.16.144-.111.304-.223.448-.335.016-.016.032-.016.032-.032 1.696-1.487 2.8-3.676 2.8-6.106zm-8 7.001c-1.504 0-2.88-.48-4.016-1.279.016-.128.048-.255.08-.383a4.17 4.17 0 0 1 .416-.991c.176-.304.384-.576.64-.816.24-.24.528-.463.816-.639.304-.176.624-.304.976-.4A4.15 4.15 0 0 1 8 10.342a4.185 4.185 0 0 1 2.928 1.166c.368.368.656.8.864 1.295.112.288.192.592.24.911A7.03 7.03 0 0 1 8 14.993zm-2.448-7.4a2.49 2.49 0 0 1-.208-1.024c0-.351.064-.703.208-1.023.144-.32.336-.607.576-.847.24-.24.528-.431.848-.575.32-.144.672-.208 1.024-.208.368 0 .704.064 1.024.208.32.144.608.336.848.575.24.24.432.528.576.847.144.32.208.672.208 1.023 0 .368-.064.704-.208 1.023a2.84 2.84 0 0 1-.576.848 2.84 2.84 0 0 1-.848.575 2.715 2.715 0 0 1-2.064 0 2.84 2.84 0 0 1-.848-.575 2.526 2.526 0 0 1-.56-.848zm7.424 5.306c0-.032-.016-.048-.016-.08a5.22 5.22 0 0 0-.688-1.406 4.883 4.883 0 0 0-1.088-1.135 5.207 5.207 0 0 0-1.04-.608 2.82 2.82 0 0 0 .464-.383 4.2 4.2 0 0 0 .624-.784 3.624 3.624 0 0 0 .528-1.934 3.71 3.71 0 0 0-.288-1.47 3.799 3.799 0 0 0-.816-1.199 3.845 3.845 0 0 0-1.2-.8 3.72 3.72 0 0 0-1.472-.287 3.72 3.72 0 0 0-1.472.288 3.631 3.631 0 0 0-1.2.815 3.84 3.84 0 0 0-.8 1.199 3.71 3.71 0 0 0-.288 1.47c0 .352.048.688.144 1.007.096.336.224.64.4.927.16.288.384.544.624.784.144.144.304.271.48.383a5.12 5.12 0 0 0-1.04.624c-.416.32-.784.703-1.088 1.119a4.999 4.999 0 0 0-.688 1.406c-.016.032-.016.064-.016.08C1.776 11.636.992 9.91.992 7.992.992 4.14 4.144.991 8 .991s7.008 3.149 7.008 7.001a6.96 6.96 0 0 1-2.032 4.907z';
-			} else if (taskNode.type === 'sendTask') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/mail.svg?short_path=d02764e
-				icon =
-					// eslint-disable-next-line max-len
-					'M1 3.5l.5-.5h13l.5.5v9l-.5.5h-13l-.5-.5v-9zm1 1.035V12h12V4.536L8.31 8.9H7.7L2 4.535zM13.03 4H2.97L8 7.869 13.03 4z';
-			} else if (taskNode.type === 'scriptTask') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/account.svg?short_path=8135b2d
-				icon =
-					// eslint-disable-next-line max-len
-					'M6 10V9h9v1H6zm4-4h5v1h-5V6zm5-3v1H6V3h9zm-9 9v1h9v-1H6z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M1 2.795l.783-.419 5.371 3.581v.838l-5.371 3.581L1 9.957V2.795zm1.007.94v5.281l3.96-2.64-3.96-2.64z';
-			}
-		}
+        if (gatewayNode) {
+            scaleFactor = 1.5;
+            translate = 9.0;
+            if (gatewayNode.type === 'parallelGateway') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/add.svg
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M14 7v1H8v6H7V8H1V7h6V1h1v6h6z';
+            } else if (gatewayNode.type === 'exclusiveGateway') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/chrome-close.svg?short_path=6b9a55a
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M7.116 8l-4.558 4.558.884.884L8 8.884l4.558 4.558.884-.884L8.884 8l4.558-4.558-.884-.884L8 7.116 3.442 2.558l-.884.884L7.116 8z';
+            } else if (gatewayNode.type === 'inclusiveGateway') {
+                // From codicons:
+                // https://github.com/microsoft/vscode-codicons/blob/main/src/icons/circle-large-outline.svg?short_path=f801c32
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M9.588 2.215A5.808 5.808 0 0 0 8 2c-.554 0-1.082.073-1.588.215l-.006.002c-.514.141-.99.342-1.432.601A6.156 6.156 0 0 0 2.82 4.98l-.002.004A5.967 5.967 0 0 0 2.21 6.41 5.986 5.986 0 0 0 2 8c0 .555.07 1.085.21 1.591a6.05 6.05 0 0 0 1.548 2.651c.37.365.774.677 1.216.94a6.1 6.1 0 0 0 1.435.609A6.02 6.02 0 0 0 8 14c.555 0 1.085-.07 1.591-.21.515-.145.99-.348 1.426-.607l.004-.002a6.16 6.16 0 0 0 2.161-2.155 5.85 5.85 0 0 0 .6-1.432l.003-.006A5.807 5.807 0 0 0 14 8c0-.554-.072-1.082-.215-1.588l-.002-.006a5.772 5.772 0 0 0-.6-1.423l-.002-.004a5.9 5.9 0 0 0-.942-1.21l-.008-.008a5.902 5.902 0 0 0-1.21-.942l-.004-.002a5.772 5.772 0 0 0-1.423-.6l-.006-.002zm4.455 9.32a7.157 7.157 0 0 1-2.516 2.508 6.966 6.966 0 0 1-1.668.71A6.984 6.984 0 0 1 8 15a6.984 6.984 0 0 1-1.86-.246 7.098 7.098 0 0 1-1.674-.711 7.3 7.3 0 0 1-1.415-1.094 7.295 7.295 0 0 1-1.094-1.415 7.098 7.098 0 0 1-.71-1.675A6.985 6.985 0 0 1 1 8c0-.643.082-1.262.246-1.86a6.968 6.968 0 0 1 .711-1.667 7.156 7.156 0 0 1 2.509-2.516 6.895 6.895 0 0 1 1.675-.704A6.808 6.808 0 0 1 8 1a6.8 6.8 0 0 1 1.86.253 6.899 6.899 0 0 1 3.083 1.805 6.903 6.903 0 0 1 1.804 3.083C14.916 6.738 15 7.357 15 8s-.084 1.262-.253 1.86a6.9 6.9 0 0 1-.704 1.674z';
+            }
+        }
 
-		if (gatewayNode) {
-			scaleFactor=1.5;
-			translate=9.0;
-			if (gatewayNode.type === 'parallelGateway') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/add.svg
-				icon =
-					// eslint-disable-next-line max-len
-					'M14 7v1H8v6H7V8H1V7h6V1h1v6h6z';
-			} else if (gatewayNode.type === 'exclusiveGateway') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/chrome-close.svg?short_path=6b9a55a
-				icon =
-					// eslint-disable-next-line max-len
-					'M7.116 8l-4.558 4.558.884.884L8 8.884l4.558 4.558.884-.884L8.884 8l4.558-4.558-.884-.884L8 7.116 3.442 2.558l-.884.884L7.116 8z';
-			} else if (gatewayNode.type === 'inclusiveGateway') {
-				// From codicons:
-				// https://github.com/microsoft/vscode-codicons/blob/main/src/icons/circle-large-outline.svg?short_path=f801c32
-				icon =
-					// eslint-disable-next-line max-len
-					'M9.588 2.215A5.808 5.808 0 0 0 8 2c-.554 0-1.082.073-1.588.215l-.006.002c-.514.141-.99.342-1.432.601A6.156 6.156 0 0 0 2.82 4.98l-.002.004A5.967 5.967 0 0 0 2.21 6.41 5.986 5.986 0 0 0 2 8c0 .555.07 1.085.21 1.591a6.05 6.05 0 0 0 1.548 2.651c.37.365.774.677 1.216.94a6.1 6.1 0 0 0 1.435.609A6.02 6.02 0 0 0 8 14c.555 0 1.085-.07 1.591-.21.515-.145.99-.348 1.426-.607l.004-.002a6.16 6.16 0 0 0 2.161-2.155 5.85 5.85 0 0 0 .6-1.432l.003-.006A5.807 5.807 0 0 0 14 8c0-.554-.072-1.082-.215-1.588l-.002-.006a5.772 5.772 0 0 0-.6-1.423l-.002-.004a5.9 5.9 0 0 0-.942-1.21l-.008-.008a5.902 5.902 0 0 0-1.21-.942l-.004-.002a5.772 5.772 0 0 0-1.423-.6l-.006-.002zm4.455 9.32a7.157 7.157 0 0 1-2.516 2.508 6.966 6.966 0 0 1-1.668.71A6.984 6.984 0 0 1 8 15a6.984 6.984 0 0 1-1.86-.246 7.098 7.098 0 0 1-1.674-.711 7.3 7.3 0 0 1-1.415-1.094 7.295 7.295 0 0 1-1.094-1.415 7.098 7.098 0 0 1-.71-1.675A6.985 6.985 0 0 1 1 8c0-.643.082-1.262.246-1.86a6.968 6.968 0 0 1 .711-1.667 7.156 7.156 0 0 1 2.509-2.516 6.895 6.895 0 0 1 1.675-.704A6.808 6.808 0 0 1 8 1a6.8 6.8 0 0 1 1.86.253 6.899 6.899 0 0 1 3.083 1.805 6.903 6.903 0 0 1 1.804 3.083C14.916 6.738 15 7.357 15 8s-.084 1.262-.253 1.86a6.9 6.9 0 0 1-.704 1.674z';
-			}
-		}
+        if (eventNode) {
+            scaleFactor = 1.5;
+            translate = 4.0;
 
-		if (eventNode) {
-			scaleFactor=1.5;
-			translate=4.0;
+            if (eventNode.symbol === 'messageEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/mail.svg?short_path=d02764e
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M1 3.5l.5-.5h13l.5.5v9l-.5.5h-13l-.5-.5v-9zm1 1.035V12h12V4.536L8.31 8.9H7.7L2 4.535zM13.03 4H2.97L8 7.869 13.03 4z';
+            } else if (eventNode.symbol === 'conditionalEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/debug-line-by-line.svg?short_path=a0335ca
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M1 2.795l.783-.419 5.371 3.581v.838l-5.371 3.581L1 9.957V2.795zm1.007.94v5.281l3.96-2.64-3.96-2.64z';
+            } else if (eventNode.symbol === 'compensationEventDefinition') {
+                // From codicons:
+                // https://github.com/microsoft/vscode-codicons/blob/main/src/icons/debug-reverse-continue.svg?short_path=5509580
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M13.5 2H12v12h1.5V2zm-4.936.39L9.75 3v10l-1.186.61-7-5V7.39l7-5zM3.29 8l4.96 3.543V4.457L3.29 8z';
+            } else if (eventNode.symbol === 'timerEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/history.svg?short_path=53d41f7
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M13.507 12.324a7 7 0 0 0 .065-8.56A7 7 0 0 0 2 4.393V2H1v3.5l.5.5H5V5H2.811a6.008 6.008 0 1 1-.135 5.77l-.887.462a7 7 0 0 0 11.718 1.092zm-3.361-.97l.708-.707L8 7.792V4H7v4l.146.354 3 3z';
+            } else if (eventNode.symbol === 'signalEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/pulse.svg?short_path=6ffbc15
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M11.8 9L10 3H9L7.158 9.64 5.99 4.69h-.97L3.85 9H1v.99h3.23l.49-.37.74-2.7L6.59 12h1.03l1.87-7.04 1.46 4.68.48.36H15V9h-3.2z';
+            } else if (eventNode.symbol === 'linkEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/run-all.svg?short_path=06e6ef9
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z';
+            } else if (eventNode.symbol === 'errorEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/github-action.svg?short_path=987d495
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M3.04 10h2.58l.65 1H2.54l-.5-.5v-9l.5-.5h12l.5.5v4.77l-1-1.75V2h-11v8zm5.54 1l-1.41 3.47h2.2L15 8.7 14.27 7h-1.63l.82-1.46L12.63 4H9.76l-.92.59-2.28 5L7.47 11h1.11zm1.18-6h2.87l-1.87 3h3.51l-5.76 5.84L10.2 10H7.47l2.29-5zM6.95 7H4.04V6H7.4l-.45 1zm-.9 2H4.04V8H6.5l-.45 1z';
+            } else if (eventNode.symbol === 'multipleEventDefinition') {
+                // From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/layers.svg?short_path=f67ac65
+                icon =
+                    // eslint-disable-next-line max-len
+                    'M7.62706 1.08717L8.18535 1.08325L14.2762 5.1203L14.2727 5.95617L8.1818 9.91912L7.63062 9.91528L1.72152 5.95233L1.71796 5.12422L7.62706 1.08717ZM7.91335 2.10268L2.89198 5.53323L7.91329 8.90079L13.0891 5.5332L7.91335 2.10268ZM1.79257 8.5L7.63059 12.4153L8.18177 12.4191L14.2053 8.5H12.3716L7.91326 11.4008L3.58794 8.5H1.79257ZM7.63059 14.9153L1.79257 11H3.58794L7.91326 13.9008L12.3716 11H14.2053L8.18177 14.9191L7.63059 14.9153Z';
+            }
+        }
 
-			if (eventNode.symbol === 'messageEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/mail.svg?short_path=d02764e
-				icon =
-				// eslint-disable-next-line max-len
-				'M1 3.5l.5-.5h13l.5.5v9l-.5.5h-13l-.5-.5v-9zm1 1.035V12h12V4.536L8.31 8.9H7.7L2 4.535zM13.03 4H2.97L8 7.869 13.03 4z';
-			} else if (eventNode.symbol === 'conditionalEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/debug-line-by-line.svg?short_path=a0335ca
-				icon =
-				// eslint-disable-next-line max-len
-				'M1 2.795l.783-.419 5.371 3.581v.838l-5.371 3.581L1 9.957V2.795zm1.007.94v5.281l3.96-2.64-3.96-2.64z';
-			} else if (eventNode.symbol === 'compensationEventDefinition') {
-				// From codicons:
-				// https://github.com/microsoft/vscode-codicons/blob/main/src/icons/debug-reverse-continue.svg?short_path=5509580
-				icon =
-				// eslint-disable-next-line max-len
-				'M13.5 2H12v12h1.5V2zm-4.936.39L9.75 3v10l-1.186.61-7-5V7.39l7-5zM3.29 8l4.96 3.543V4.457L3.29 8z';
-			} else if (eventNode.symbol === 'timerEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/history.svg?short_path=53d41f7
-				icon =
-				// eslint-disable-next-line max-len
-				'M13.507 12.324a7 7 0 0 0 .065-8.56A7 7 0 0 0 2 4.393V2H1v3.5l.5.5H5V5H2.811a6.008 6.008 0 1 1-.135 5.77l-.887.462a7 7 0 0 0 11.718 1.092zm-3.361-.97l.708-.707L8 7.792V4H7v4l.146.354 3 3z';
-			} else if (eventNode.symbol === 'signalEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/pulse.svg?short_path=6ffbc15
-				icon =
-				// eslint-disable-next-line max-len
-				'M11.8 9L10 3H9L7.158 9.64 5.99 4.69h-.97L3.85 9H1v.99h3.23l.49-.37.74-2.7L6.59 12h1.03l1.87-7.04 1.46 4.68.48.36H15V9h-3.2z';
+        // did we have now a icon?
+        if (!icon) {
+            return undefined;
+        }
 
-			} else if (eventNode.symbol === 'linkEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/run-all.svg?short_path=06e6ef9
-				icon =
-				// eslint-disable-next-line max-len
-				'M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z';
-			} else if (eventNode.symbol === 'errorEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/github-action.svg?short_path=987d495
-				icon =
-				// eslint-disable-next-line max-len
-				'M3.04 10h2.58l.65 1H2.54l-.5-.5v-9l.5-.5h12l.5.5v4.77l-1-1.75V2h-11v8zm5.54 1l-1.41 3.47h2.2L15 8.7 14.27 7h-1.63l.82-1.46L12.63 4H9.76l-.92.59-2.28 5L7.47 11h1.11zm1.18-6h2.87l-1.87 3h3.51l-5.76 5.84L10.2 10H7.47l2.29-5zM6.95 7H4.04V6H7.4l-.45 1zm-.9 2H4.04V8H6.5l-.45 1z';
-			
-			} else if (eventNode.symbol === 'multipleEventDefinition') {
-				// From codicons: https://github.com/microsoft/vscode-codicons/blob/main/src/icons/layers.svg?short_path=f67ac65
-				icon =
-				// eslint-disable-next-line max-len
-				'M7.62706 1.08717L8.18535 1.08325L14.2762 5.1203L14.2727 5.95617L8.1818 9.91912L7.63062 9.91528L1.72152 5.95233L1.71796 5.12422L7.62706 1.08717ZM7.91335 2.10268L2.89198 5.53323L7.91329 8.90079L13.0891 5.5332L7.91335 2.10268ZM1.79257 8.5L7.63059 12.4153L8.18177 12.4191L14.2053 8.5H12.3716L7.91326 11.4008L3.58794 8.5H1.79257ZM7.63059 14.9153L1.79257 11H3.58794L7.91326 13.9008L12.3716 11H14.2053L8.18177 14.9191L7.63059 14.9153Z';
-			}
-		}
+        const vnode: any = (
+            <g>
+                <path transform={'scale(' + scaleFactor + '),translate(' + translate + ',' + translate + ')'} d={icon} />
+            </g>
+        );
 
-		// did we have now a icon?
-		if (!icon) {
-			return undefined;
-		}
-
-		const vnode: any = (
-			<g>
-				<path transform={'scale(' + scaleFactor + '),translate(' + translate + ',' + translate+')'}
-					d={icon}
-				/>				
-			</g>
-		);
-
-		const subType = getSubType(element);
-		if (subType) {
-			setAttr(vnode, 'class', subType);
-		}
-		return vnode;
-	}
+        const subType = getSubType(element);
+        if (subType) {
+            setAttr(vnode, 'class', subType);
+        }
+        return vnode;
+    }
 }
 
 /**
@@ -190,11 +184,11 @@ export class BPMNLabelNodeSelectionListener implements SelectionListener {
     @inject(TYPES.IActionDispatcher)
     protected actionDispatcher: ActionDispatcher;
     selectionChanged(root: Readonly<SModelRoot>, selectedElements: string[]): void {
-		// we are only intersted in Events and Gateways
-		const eventNodes=  getElements(root.index,selectedElements,isBPMNLabelNode);
-		if (eventNodes.length > 0) {
-			// find the associated BPMNLabels
-			const eventLabelIds = eventNodes.map(node => node.id+'_bpmnlabel');
+        // we are only intersted in Events and Gateways
+        const eventNodes = getElements(root.index, selectedElements, isBPMNLabelNode);
+        if (eventNodes.length > 0) {
+            // find the associated BPMNLabels
+            const eventLabelIds = eventNodes.map(node => node.id + '_bpmnlabel');
             this.actionDispatcher.dispatch(SelectAction.create({ selectedElementsIDs: eventLabelIds }));
         }
     }

--- a/open-bpmn.glsp-client/open-bpmn-glsp/src/bpmn-helperlines.tsx
+++ b/open-bpmn.glsp-client/open-bpmn-glsp/src/bpmn-helperlines.tsx
@@ -14,20 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-	Action, SModelElement, SLabel, SModelRoot, MouseListener, FeedbackCommand, hasObjectProp, isBoundsAware, //
-	ISnapper
+    Action,
+    FeedbackCommand,
+    hasObjectProp,
+    isBoundsAware,
+    ISnapper,
+    MouseListener,
+    SLabel,
+    SModelElement,
+    SModelRoot
 } from '@eclipse-glsp/client';
+import { isBPMNNode, isEventNode, isGatewayNode } from '@open-bpmn/open-bpmn-model';
 import { inject, injectable } from 'inversify';
-import {
-	SChildElement,
-	CommandExecutionContext,
-	CommandReturn,
-	svg, IView, RenderingContext, getAbsoluteBounds,
-	TYPES
-} from 'sprotty';
 import { VNode } from 'snabbdom';
+import { CommandExecutionContext, CommandReturn, getAbsoluteBounds, IView, RenderingContext, SChildElement, svg, TYPES } from 'sprotty';
 import { Bounds, Point } from 'sprotty-protocol';
-import { isBPMNNode,isEventNode,isGatewayNode } from '@open-bpmn/open-bpmn-model';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const JSX = { createElement: svg };
 
@@ -48,21 +49,21 @@ const JSX = { createElement: svg };
  * to containing a list of helperLines.
  */
 export class HelperLinesElement extends SChildElement {
-	override type: string;
-	override id: string;
-	readonly helperLines: ReadonlyArray<HelperLine> = [];
-	constructor(type: string, id: string, helperLines: HelperLine[]) {
-		super();
-		this.type = type;
-		this.id = id;
-		this.helperLines = helperLines;
-	}
+    override type: string;
+    override id: string;
+    readonly helperLines: ReadonlyArray<HelperLine> = [];
+    constructor(type: string, id: string, helperLines: HelperLine[]) {
+        super();
+        this.type = type;
+        this.id = id;
+        this.helperLines = helperLines;
+    }
 }
 export interface HelperLine {
-	readonly x1: number
-	readonly y1: number
-	readonly x2: number
-	readonly y2: number
+    readonly x1: number;
+    readonly y1: number;
+    readonly x2: number;
+    readonly y2: number;
 }
 
 /**
@@ -73,108 +74,105 @@ export interface HelperLine {
  */
 @injectable()
 export class BPMNElementSnapper implements ISnapper {
-
-	get snapRange(): number {
+    get snapRange(): number {
         return 10;
     }
 
-	/* Find a possible snapPoint.
-	 * a SnapPoint is found if the x or y coordinates matching the position
-	 * of another element Node.
-	 * We are only interested in BPMNNode elemnets. For all other element we return
-	 * the default.
-	 */
+    /* Find a possible snapPoint.
+     * a SnapPoint is found if the x or y coordinates matching the position
+     * of another element Node.
+     * We are only interested in BPMNNode elemnets. For all other element we return
+     * the default.
+     */
     snap(position: Point, element: SModelElement): Point {
-		if (!isBPMNNode(element)) {
-			// return position;
-			return {x:position.x,y:position.y};
-		}
-		// find snap position
-		const snapPoint: Point = this.findSnapPoint(element);
-		// if a snapPoint was found and this snapPoint is still in the snapRange,
-		// then we adjust the current mouse Postion. Otherwise we return the current position
-		const y=(snapPoint.y>-1 && Math.abs(position.y-snapPoint.y)<=this.snapRange)?snapPoint.y: position.y;
-		const x=(snapPoint.x>-1 && Math.abs(position.x-snapPoint.x)<=this.snapRange)?snapPoint.x: position.x;
-		const xSnap=(x-position.x);
-		const ySnap=(y-position.y);
-		// fix label ofset (only needed or Events and Gateways)?
-		if ((isEventNode(element) || isGatewayNode(element)) && (ySnap!==0 || xSnap!==0)) {
-			const label: any=element.root.index.getById(element.id + '_bpmnlabel');
-			if (label instanceof SLabel) {			
-				// fix ofset of the lable position....
-				const ly=label.position.y+ySnap;
-				const lx=label.position.x +xSnap;
-				label.position={x:lx,y:ly};
-			}
-		}
+        if (!isBPMNNode(element)) {
+            // return position;
+            return { x: position.x, y: position.y };
+        }
+        // find snap position
+        const snapPoint: Point = this.findSnapPoint(element);
+        // if a snapPoint was found and this snapPoint is still in the snapRange,
+        // then we adjust the current mouse Postion. Otherwise we return the current position
+        const y = snapPoint.y > -1 && Math.abs(position.y - snapPoint.y) <= this.snapRange ? snapPoint.y : position.y;
+        const x = snapPoint.x > -1 && Math.abs(position.x - snapPoint.x) <= this.snapRange ? snapPoint.x : position.x;
+        const xSnap = x - position.x;
+        const ySnap = y - position.y;
+        // fix label ofset (only needed or Events and Gateways)?
+        if ((isEventNode(element) || isGatewayNode(element)) && (ySnap !== 0 || xSnap !== 0)) {
+            const label: any = element.root.index.getById(element.id + '_bpmnlabel');
+            if (label instanceof SLabel) {
+                // fix ofset of the lable position....
+                const ly = label.position.y + ySnap;
+                const lx = label.position.x + xSnap;
+                label.position = { x: lx, y: ly };
+            }
+        }
 
-        return {x:x,y:y};
+        return { x: x, y: y };
     }
 
-	/*
-	 * This helper method searches the model for model elements
-	 * matching the horizontal and/or vertical alligment of the given modelElement.
-	 *
-	 * A ModelElement is a alligned to another element if its center point matches
-	 * the same x or y axis. The method retuns up to two elements - vertical and/or horizontal
-	 *
-	 * The method takes into account an approximation of 10. (See method 'isNear')
+    /*
+     * This helper method searches the model for model elements
+     * matching the horizontal and/or vertical alligment of the given modelElement.
      *
-	 */
-	private findSnapPoint(modelElement: SModelElement): Point {
-		let root: any;
-		try 
-		{
-			root = modelElement.root;
-		}
-		catch (e: unknown) {
-			// unable to get root (during creation)
-		}
+     * A ModelElement is a alligned to another element if its center point matches
+     * the same x or y axis. The method retuns up to two elements - vertical and/or horizontal
+     *
+     * The method takes into account an approximation of 10. (See method 'isNear')
+     *
+     */
+    private findSnapPoint(modelElement: SModelElement): Point {
+        let root: any;
+        try {
+            root = modelElement.root;
+        } catch (e: unknown) {
+            // unable to get root (during creation)
+        }
 
-		let x=-1;
-		let y=-1;
+        let x = -1;
+        let y = -1;
 
-		if (root && isBoundsAware(modelElement)) {
-			const childs = root.children;
-			const modelElementCenter = Bounds.center(modelElement.bounds);
-			// In the following we iterate over all model elements
-			// and compare the x and y axis of the center points
-			for (const element of childs) {
-				if (element.id !== modelElement.id && isBPMNNode(element) && isBoundsAware(element)) {
-					const elementCenter = Bounds.center(element.bounds);
-					if (elementCenter && modelElementCenter) {
-						// test horizontal alligment...
-						if (y===-1 && this.isNear(elementCenter.y, modelElementCenter.y)) {
-							// fount horizontal snap point
-							y=elementCenter.y-(modelElement.bounds.height*0.5);
-						}
-						// test vertical alligment...
-						if (x===-1 && this.isNear(elementCenter.x, modelElementCenter.x)) {
-							// found vertical snap point!
-							x=elementCenter.x-(modelElement.bounds.width*0.5);
-						}
-					}
-				}
-				if (x>-1 && y>-1) {
-					// we can break here as we found already the maximum of two possible matches.
-					break;
-				}
-			}
-		}
-		// return snapoint (-1,-1 if not match was found)
-		return {x:x,y:y};
-	}
+        if (root && isBoundsAware(modelElement)) {
+            const childs = root.children;
+            const modelElementCenter = Bounds.center(modelElement.bounds);
+            // In the following we iterate over all model elements
+            // and compare the x and y axis of the center points
+            for (const element of childs) {
+                if (element.id !== modelElement.id && isBPMNNode(element) && isBoundsAware(element)) {
+                    const elementCenter = Bounds.center(element.bounds);
+                    if (elementCenter && modelElementCenter) {
+                        // test horizontal alligment...
+                        if (y === -1 && this.isNear(elementCenter.y, modelElementCenter.y)) {
+                            // fount horizontal snap point
+                            y = elementCenter.y - modelElement.bounds.height * 0.5;
+                        }
+                        // test vertical alligment...
+                        if (x === -1 && this.isNear(elementCenter.x, modelElementCenter.x)) {
+                            // found vertical snap point!
+                            x = elementCenter.x - modelElement.bounds.width * 0.5;
+                        }
+                    }
+                }
+                if (x > -1 && y > -1) {
+                    // we can break here as we found already the maximum of two possible matches.
+                    break;
+                }
+            }
+        }
+        // return snapoint (-1,-1 if not match was found)
+        return { x: x, y: y };
+    }
 
     /**
      * Returns true if the values are in a range of 10
      */
-	private isNear(p1: number, p2: number): boolean {
-		const p3=Math.abs(p1-p2);
-		if (p3<this.snapRange) {
-			return true;
-		}
-		return false;
-	}
+    private isNear(p1: number, p2: number): boolean {
+        const p3 = Math.abs(p1 - p2);
+        if (p3 < this.snapRange) {
+            return true;
+        }
+        return false;
+    }
 }
 
 /*
@@ -183,142 +181,142 @@ export class BPMNElementSnapper implements ISnapper {
  */
 @injectable()
 export class HelperLineListener extends MouseListener {
-	protected isActive = false;
+    protected isActive = false;
 
-	override mouseDown(target: SModelElement, event: MouseEvent): Action[] {
-		// check if target is relevant....
-		if (isBPMNNode(target) || target.type==='icon') {
-			// switch into active mode
-			this.isActive = true;
-		} else {
-			this.isActive = false;
-		}
-		return [];
-	}
+    override mouseDown(target: SModelElement, event: MouseEvent): Action[] {
+        // check if target is relevant....
+        if (isBPMNNode(target) || target.type === 'icon') {
+            // switch into active mode
+            this.isActive = true;
+        } else {
+            this.isActive = false;
+        }
+        return [];
+    }
 
-	/**
-	 * This method acts on a mouseMove event if a BPMN element is selected (isActive==true).
-	 * The method computes a list of helperLines to alligned elements in the diagram.
-	 * If helper lines where found, the method fires the corresponding
-	 * command to draw the helper lines.
-	 */
-	override mouseMove(target: SModelElement, event: MouseEvent): Action[] {
-		if (this.isActive) {
-			// first test if we have a mouseMove on a BPMNNode
-			// const bpmnNode = isBPMNNode(target);
-			if (isBPMNNode(target)) {
-				const helperLines: HelperLine[] | undefined = this.findHelperLines(target);
-				if (helperLines) {
-					return [DrawHelperLinesAction.create({ helperLines: helperLines })];
-				} else {
-					// now match! remove helper lines...
-					return [RemoveHelperLinesAction.create()];
-				}
-			}
-		}
-		return [];
-	}
+    /**
+     * This method acts on a mouseMove event if a BPMN element is selected (isActive==true).
+     * The method computes a list of helperLines to alligned elements in the diagram.
+     * If helper lines where found, the method fires the corresponding
+     * command to draw the helper lines.
+     */
+    override mouseMove(target: SModelElement, event: MouseEvent): Action[] {
+        if (this.isActive) {
+            // first test if we have a mouseMove on a BPMNNode
+            // const bpmnNode = isBPMNNode(target);
+            if (isBPMNNode(target)) {
+                const helperLines: HelperLine[] | undefined = this.findHelperLines(target);
+                if (helperLines) {
+                    return [DrawHelperLinesAction.create({ helperLines: helperLines })];
+                } else {
+                    // now match! remove helper lines...
+                    return [RemoveHelperLinesAction.create()];
+                }
+            }
+        }
+        return [];
+    }
 
-	/*
-	 * On the mouseUp event we end the active mode and
-	 * remove the HelperLines from the model
-	 */
-	override mouseUp(target: SModelElement, event: MouseEvent): Action[] {
-		this.isActive = false;
-		return [RemoveHelperLinesAction.create()]; //  EnableDefaultToolsAction.create()
-	}
+    /*
+     * On the mouseUp event we end the active mode and
+     * remove the HelperLines from the model
+     */
+    override mouseUp(target: SModelElement, event: MouseEvent): Action[] {
+        this.isActive = false;
+        return [RemoveHelperLinesAction.create()]; //  EnableDefaultToolsAction.create()
+    }
 
-	/*
-	 * This helper method searches the model for model elements
-	 * matching the horizontal and/or vertical alligment of the given modelElement.
-	 *
-	 * A ModelElement is a alligned to another element if its center point matches
-	 * the same x or y axis. The method retuns up to two helper lines. The helper lines
-	 * go through the full dimensions of the canvas.
-	 *
-	 * The method can be extended to find  more helper lines with a differnt algorythm.
-	 */
-	private findHelperLines(modelElement: SModelElement): HelperLine[] | undefined {
-		const root: SModelRoot = modelElement.root;
-		const helperLines: HelperLine[] = [];
-		if (root  && isBoundsAware(modelElement)) {
-			const childs = root.children;
-			const canvasBounds = root.canvasBounds;
-			// compute absolute center bounds of the model element. This is needed to compute the
-			// dimensions of the drawing canvas.
-			const absoluteCenterBounds = Bounds.center(getAbsoluteBounds(modelElement));
-			// const modelElementCenter = Bounds.center(modelElement.bounds);
-			const modelElementCenter = Bounds.center(modelElement.bounds);
-			// In the following we iterate over all model elements
-			// and compare the x and y axis of the center points
-			let foundHorizontal = false;
-			let foundVertical = false;
-			for (const element of childs) {
-				if (element.id !== modelElement.id && isBPMNNode(element) && isBoundsAware(element)) {
-					// const elementCenter = Bounds.center(element.bounds);
-					const elementCenter = Bounds.center(element.bounds);
-					if (elementCenter && modelElementCenter) {
-						// test vertical alligment...
-						if (!foundHorizontal && elementCenter.y === modelElementCenter.y) {
-							const horizontalLine: HelperLine = {
-								x1: modelElementCenter.x - absoluteCenterBounds.x,
-								y1: elementCenter.y,
-								x2: modelElementCenter.x - absoluteCenterBounds.x + canvasBounds.width,
-								y2: elementCenter.y
-							};
-							foundHorizontal = true;
-							helperLines.push(horizontalLine);
-						}
-						// test horizontal alligment...
-						if (!foundVertical && elementCenter.x === modelElementCenter.x) {
-							const verticalLine: HelperLine = {
-								y1: modelElementCenter.y - absoluteCenterBounds.y,
-								x1: elementCenter.x,
-								y2: modelElementCenter.y - absoluteCenterBounds.y + canvasBounds.height,
-								x2: elementCenter.x
-							};
-							foundVertical = true;
-							helperLines.push(verticalLine);
-						}
-					}
-				}
-				if (foundHorizontal === true && foundVertical === true) {
-					// we can break here as we found already two possible matches.
-					break;
-				}
-			}
-		}
-		if (helperLines.length > 0) {
-			return helperLines;
-		}
-		return undefined;
-	}
+    /*
+     * This helper method searches the model for model elements
+     * matching the horizontal and/or vertical alligment of the given modelElement.
+     *
+     * A ModelElement is a alligned to another element if its center point matches
+     * the same x or y axis. The method retuns up to two helper lines. The helper lines
+     * go through the full dimensions of the canvas.
+     *
+     * The method can be extended to find  more helper lines with a differnt algorythm.
+     */
+    private findHelperLines(modelElement: SModelElement): HelperLine[] | undefined {
+        const root: SModelRoot = modelElement.root;
+        const helperLines: HelperLine[] = [];
+        if (root && isBoundsAware(modelElement)) {
+            const childs = root.children;
+            const canvasBounds = root.canvasBounds;
+            // compute absolute center bounds of the model element. This is needed to compute the
+            // dimensions of the drawing canvas.
+            const absoluteCenterBounds = Bounds.center(getAbsoluteBounds(modelElement));
+            // const modelElementCenter = Bounds.center(modelElement.bounds);
+            const modelElementCenter = Bounds.center(modelElement.bounds);
+            // In the following we iterate over all model elements
+            // and compare the x and y axis of the center points
+            let foundHorizontal = false;
+            let foundVertical = false;
+            for (const element of childs) {
+                if (element.id !== modelElement.id && isBPMNNode(element) && isBoundsAware(element)) {
+                    // const elementCenter = Bounds.center(element.bounds);
+                    const elementCenter = Bounds.center(element.bounds);
+                    if (elementCenter && modelElementCenter) {
+                        // test vertical alligment...
+                        if (!foundHorizontal && elementCenter.y === modelElementCenter.y) {
+                            const horizontalLine: HelperLine = {
+                                x1: modelElementCenter.x - absoluteCenterBounds.x,
+                                y1: elementCenter.y,
+                                x2: modelElementCenter.x - absoluteCenterBounds.x + canvasBounds.width,
+                                y2: elementCenter.y
+                            };
+                            foundHorizontal = true;
+                            helperLines.push(horizontalLine);
+                        }
+                        // test horizontal alligment...
+                        if (!foundVertical && elementCenter.x === modelElementCenter.x) {
+                            const verticalLine: HelperLine = {
+                                y1: modelElementCenter.y - absoluteCenterBounds.y,
+                                x1: elementCenter.x,
+                                y2: modelElementCenter.y - absoluteCenterBounds.y + canvasBounds.height,
+                                x2: elementCenter.x
+                            };
+                            foundVertical = true;
+                            helperLines.push(verticalLine);
+                        }
+                    }
+                }
+                if (foundHorizontal === true && foundVertical === true) {
+                    // we can break here as we found already two possible matches.
+                    break;
+                }
+            }
+        }
+        if (helperLines.length > 0) {
+            return helperLines;
+        }
+        return undefined;
+    }
 }
 
 export const HELPLINE = 'helpline';
 
 export function helpLineId(root: SModelRoot): string {
-	return root.id + '_' + HELPLINE;
+    return root.id + '_' + HELPLINE;
 }
 
 /**
  * DrawHelperLines Action
  */
 export interface DrawHelperLinesAction extends Action {
-	kind: typeof DrawHelperLinesAction.KIND;
-	helperLines: HelperLine[];
+    kind: typeof DrawHelperLinesAction.KIND;
+    helperLines: HelperLine[];
 }
 export namespace DrawHelperLinesAction {
-	export const KIND = 'drawHelperLines';
-	export function is(object: any): object is DrawHelperLinesAction {
-		return Action.hasKind(object, KIND) && hasObjectProp(object, 'helperLines');
-	}
-	export function create(options: { helperLines: HelperLine[]; }): DrawHelperLinesAction {
-		return {
-			kind: KIND,
-			...options
-		};
-	}
+    export const KIND = 'drawHelperLines';
+    export function is(object: any): object is DrawHelperLinesAction {
+        return Action.hasKind(object, KIND) && hasObjectProp(object, 'helperLines');
+    }
+    export function create(options: { helperLines: HelperLine[] }): DrawHelperLinesAction {
+        return {
+            kind: KIND,
+            ...options
+        };
+    }
 }
 
 /*
@@ -327,33 +325,33 @@ export namespace DrawHelperLinesAction {
  */
 @injectable()
 export class DrawHelperLinesCommand extends FeedbackCommand {
-	static readonly KIND = DrawHelperLinesAction.KIND;
+    static readonly KIND = DrawHelperLinesAction.KIND;
 
-	constructor(@inject(TYPES.Action) protected action: DrawHelperLinesAction) {
-		super();
-	}
-	execute(context: CommandExecutionContext): CommandReturn {
-		const root = context.root;
-		removeHelperLines(root);
-		// create new helperLineElement....
-		const helperLineElement = new HelperLinesElement(HELPLINE, helpLineId(root), this.action.helperLines);
-		root.add(helperLineElement);
-		return context.root;
-	}
+    constructor(@inject(TYPES.Action) protected action: DrawHelperLinesAction) {
+        super();
+    }
+    execute(context: CommandExecutionContext): CommandReturn {
+        const root = context.root;
+        removeHelperLines(root);
+        // create new helperLineElement....
+        const helperLineElement = new HelperLinesElement(HELPLINE, helpLineId(root), this.action.helperLines);
+        root.add(helperLineElement);
+        return context.root;
+    }
 }
 
 export interface RemoveHelperLinesAction extends Action {
-	kind: typeof RemoveHelperLinesAction.KIND;
+    kind: typeof RemoveHelperLinesAction.KIND;
 }
 
 export namespace RemoveHelperLinesAction {
-	export const KIND = 'removeHelperLines';
-	export function is(object: any): object is RemoveHelperLinesAction {
-		return Action.hasKind(object, KIND);
-	}
-	export function create(): RemoveHelperLinesAction {
-		return { kind: KIND };
-	}
+    export const KIND = 'removeHelperLines';
+    export function is(object: any): object is RemoveHelperLinesAction {
+        return Action.hasKind(object, KIND);
+    }
+    export function create(): RemoveHelperLinesAction {
+        return { kind: KIND };
+    }
 }
 
 /*
@@ -362,11 +360,11 @@ export namespace RemoveHelperLinesAction {
  */
 @injectable()
 export class RemoveHelperLinesCommand extends FeedbackCommand {
-	static readonly KIND = RemoveHelperLinesAction.KIND;
-	execute(context: CommandExecutionContext): CommandReturn {
-		removeHelperLines(context.root);
-		return context.root;
-	}
+    static readonly KIND = RemoveHelperLinesAction.KIND;
+    execute(context: CommandExecutionContext): CommandReturn {
+        removeHelperLines(context.root);
+        return context.root;
+    }
 }
 
 /*
@@ -374,10 +372,10 @@ export class RemoveHelperLinesCommand extends FeedbackCommand {
  * from the model.
  */
 export function removeHelperLines(root: SModelRoot): void {
-	const helperLines = root.index.getById(helpLineId(root));
-	if (helperLines instanceof SChildElement) {
-		root.remove(helperLines);
-	}
+    const helperLines = root.index.getById(helpLineId(root));
+    if (helperLines instanceof SChildElement) {
+        root.remove(helperLines);
+    }
 }
 
 /*
@@ -388,24 +386,22 @@ export function removeHelperLines(root: SModelRoot): void {
  */
 @injectable()
 export class HelperLineView implements IView {
-	render(model: Readonly<SModelElement>, context: RenderingContext): VNode {
-		const helperLines: ReadonlyArray<HelperLine> = (model as HelperLinesElement).helperLines;
-		let vnode: any;
-		// draw only one helper line?
-		if (helperLines.length === 1) {
-			vnode = (
-				<line x1={helperLines[0].x1} y1={helperLines[0].y1} x2={helperLines[0].x2} y2={helperLines[0].y2} class-helper-line />
-			);
-		}
-		// draw two helper lines (horizontal|vertical)
-		if (helperLines.length === 2) {
-			vnode = (
-				<g>
-					<line x1={helperLines[0].x1} y1={helperLines[0].y1} x2={helperLines[0].x2} y2={helperLines[0].y2} class-helper-line />
-					<line x1={helperLines[1].x1} y1={helperLines[1].y1} x2={helperLines[1].x2} y2={helperLines[1].y2} class-helper-line />
-				</g>
-			);
-		}
-		return vnode;
-	}
+    render(model: Readonly<SModelElement>, context: RenderingContext): VNode {
+        const helperLines: ReadonlyArray<HelperLine> = (model as HelperLinesElement).helperLines;
+        let vnode: any;
+        // draw only one helper line?
+        if (helperLines.length === 1) {
+            vnode = <line x1={helperLines[0].x1} y1={helperLines[0].y1} x2={helperLines[0].x2} y2={helperLines[0].y2} class-helper-line />;
+        }
+        // draw two helper lines (horizontal|vertical)
+        if (helperLines.length === 2) {
+            vnode = (
+                <g>
+                    <line x1={helperLines[0].x1} y1={helperLines[0].y1} x2={helperLines[0].x2} y2={helperLines[0].y2} class-helper-line />
+                    <line x1={helperLines[1].x1} y1={helperLines[1].y1} x2={helperLines[1].x2} y2={helperLines[1].y2} class-helper-line />
+                </g>
+            );
+        }
+        return vnode;
+    }
 }

--- a/open-bpmn.glsp-client/open-bpmn-glsp/src/bpmn-routing-views.tsx
+++ b/open-bpmn.glsp-client/open-bpmn-glsp/src/bpmn-routing-views.tsx
@@ -14,14 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-	angleOfPoint,
-	Point,
-	PolylineEdgeViewWithGapsOnIntersections,
-	RenderingContext,
-	SEdge,
-	IViewArgs,
-	isIntersectingRoutedPoint,
-	toDegrees
+    angleOfPoint,
+    isIntersectingRoutedPoint,
+    IViewArgs,
+    Point,
+    PolylineEdgeViewWithGapsOnIntersections,
+    RenderingContext,
+    SEdge,
+    toDegrees
 } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
@@ -40,124 +40,120 @@ const JSX = { createElement: svg };
 
 @injectable()
 export class BPMNSequenceFlowView extends PolylineEdgeViewWithGapsOnIntersections {
-	protected override renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
-		const additionals = super.renderAdditionals(edge, segments, context);
-		const p1 = segments[segments.length - 2];
-		const p2 = segments[segments.length - 1];
+    protected override renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
+        const additionals = super.renderAdditionals(edge, segments, context);
+        const p1 = segments[segments.length - 2];
+        const p2 = segments[segments.length - 1];
 
-		const arrow: any = (
-			<path
-				class-sprotty-edge={true}
-				class-arrow={true}
-				d='M 1,0 L 14,-4 L 14,4 Z'
-				transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y
-					})`}
-			/>
-		);
-		additionals.push(arrow);
-		return additionals;
-	}
+        const arrow: any = (
+            <path
+                class-sprotty-edge={true}
+                class-arrow={true}
+                d='M 1,0 L 14,-4 L 14,4 Z'
+                transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${p2.y}) translate(${p2.x} ${
+                    p2.y
+                })`}
+            />
+        );
+        additionals.push(arrow);
+        return additionals;
+    }
 
-	/*
-	 * The goal of this method is to render rounded corners. Therefore we compute always the next segment to decide
-	 * the corner angle.
-	 */
-	protected override renderLine(edge: SEdge, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
-		let path = '';
-		// let radius = 10;
-		let radius = 10;
-		for (let i = 0; i < segments.length; i++) {
-			const p = segments[i];
-			// start point?
-			if (i === 0) {
-				path = `M ${p.x},${p.y}`;
-			}
-			if (isIntersectingRoutedPoint(p)) {
-				path += this.intersectionPath(edge, segments, p, args);
-			}
-			// line...
-			if (i > 0) {
-				// compute the direction of the next line...
-				if (i < segments.length - 1) {
-					const plast = segments[i - 1];
-					const pnext = segments[i + 1];
-					// draw lines ending with rounded corners...
-					// right-down  ↴
-					radius=this.computeMaxRadius(p,plast,pnext);
-					if (plast.x < p.x && p.y < pnext.y) {
-						path += ` L ${p.x - radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y + radius}`;
-						// down-right  ↳
-					} else if (plast.y < p.y && p.x < pnext.x) {
-						path += ` L ${p.x},${p.y - radius}  Q ${p.x},${p.y} ${p.x + radius},${p.y}`;
-						// right-up  _↑
-					} else if (plast.x < p.x && p.y > pnext.y) {
-						path += ` L ${p.x - radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y - radius}`;
-						// up-right  ↱
-					} else if (plast.y > p.y && p.x < pnext.x) {
-						path += ` L ${p.x},${p.y + radius}  Q ${p.x},${p.y} ${p.x + radius},${p.y}`;
-						// down-left  ↲
-					} else if (plast.y < p.y && p.x > pnext.x) {
-						path += ` L ${p.x},${p.y - radius}  Q ${p.x},${p.y} ${p.x - radius},${p.y}`;
-						// left-down  ↓-
-					} else if (plast.x > p.x && p.y < pnext.y) {
-						path += ` L ${p.x + radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y + radius}`;
-						// up-left  ↰
-					} else if (plast.y > p.y && p.x > pnext.x) {
-						path += ` L ${p.x},${p.y + radius}  Q ${p.x},${p.y} ${p.x - radius},${p.y}`;
-						// left-up ↑_
-					} else if (plast.x > p.x && p.y > pnext.y) {
-						path += ` L ${p.x + radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y - radius}`;
-					} else {
-						// default
-						path += ` L ${p.x},${p.y}`;
-					}
-					
+    /*
+     * The goal of this method is to render rounded corners. Therefore we compute always the next segment to decide
+     * the corner angle.
+     */
+    protected override renderLine(edge: SEdge, segments: Point[], context: RenderingContext, args?: IViewArgs): VNode {
+        let path = '';
+        // let radius = 10;
+        let radius = 10;
+        for (let i = 0; i < segments.length; i++) {
+            const p = segments[i];
+            // start point?
+            if (i === 0) {
+                path = `M ${p.x},${p.y}`;
+            }
+            if (isIntersectingRoutedPoint(p)) {
+                path += this.intersectionPath(edge, segments, p, args);
+            }
+            // line...
+            if (i > 0) {
+                // compute the direction of the next line...
+                if (i < segments.length - 1) {
+                    const plast = segments[i - 1];
+                    const pnext = segments[i + 1];
+                    // draw lines ending with rounded corners...
+                    // right-down  ↴
+                    radius = this.computeMaxRadius(p, plast, pnext);
+                    if (plast.x < p.x && p.y < pnext.y) {
+                        path += ` L ${p.x - radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y + radius}`;
+                        // down-right  ↳
+                    } else if (plast.y < p.y && p.x < pnext.x) {
+                        path += ` L ${p.x},${p.y - radius}  Q ${p.x},${p.y} ${p.x + radius},${p.y}`;
+                        // right-up  _↑
+                    } else if (plast.x < p.x && p.y > pnext.y) {
+                        path += ` L ${p.x - radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y - radius}`;
+                        // up-right  ↱
+                    } else if (plast.y > p.y && p.x < pnext.x) {
+                        path += ` L ${p.x},${p.y + radius}  Q ${p.x},${p.y} ${p.x + radius},${p.y}`;
+                        // down-left  ↲
+                    } else if (plast.y < p.y && p.x > pnext.x) {
+                        path += ` L ${p.x},${p.y - radius}  Q ${p.x},${p.y} ${p.x - radius},${p.y}`;
+                        // left-down  ↓-
+                    } else if (plast.x > p.x && p.y < pnext.y) {
+                        path += ` L ${p.x + radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y + radius}`;
+                        // up-left  ↰
+                    } else if (plast.y > p.y && p.x > pnext.x) {
+                        path += ` L ${p.x},${p.y + radius}  Q ${p.x},${p.y} ${p.x - radius},${p.y}`;
+                        // left-up ↑_
+                    } else if (plast.x > p.x && p.y > pnext.y) {
+                        path += ` L ${p.x + radius},${p.y}  Q ${p.x},${p.y} ${p.x},${p.y - radius}`;
+                    } else {
+                        // default
+                        path += ` L ${p.x},${p.y}`;
+                    }
+                } else {
+                    // default behaviour
+                    path += ` L ${p.x},${p.y}`;
+                }
+            }
+        }
 
-				} else {
-					// default behaviour
-					path += ` L ${p.x},${p.y}`;
-				}
-			}
-		}
+        const vnode: any = <path d={path} />;
+        return vnode;
+        // return <path d={path} />;
+    }
 
-		const vnode: any = (
-			<path d={path} />
-		);
-		return vnode;
-		// return <path d={path} />;
-	}
-	
-	/**
-	 * Helper method to compute the maximum possible radius. 
-	 * If two poins are very close the radius need to be reduced 
-	 */
-	protected computeMaxRadius(pCurrent: Point, pLast: Point, pNext: Point): number {
-		let radius = 10;
-		const dRef=0.5
-		// verfiy last point
-		let xDif=Math.abs(pCurrent.x-pLast.x);
-		let yDif=Math.abs(pCurrent.y-pLast.y);
-		if ( xDif>0 && xDif<10) {
-			radius=xDif*dRef;
-			return radius;
-		}
-		if (yDif>0 && yDif <10) {
-			radius=yDif*dRef;
-			return radius;
-		}
-		// verify next point
-		xDif=Math.abs(pCurrent.x-pNext.x);
-		yDif=Math.abs(pCurrent.y-pNext.y);
-		if ( xDif>0 && xDif<10) {
-			radius=xDif*dRef;
-			return radius;
-		}
-		if (yDif>0 && yDif <10) {
-			radius=yDif*dRef;
-			return radius;
-		}
-		// default
-		return radius;
-	}
-	
+    /**
+     * Helper method to compute the maximum possible radius.
+     * If two poins are very close the radius need to be reduced
+     */
+    protected computeMaxRadius(pCurrent: Point, pLast: Point, pNext: Point): number {
+        let radius = 10;
+        const dRef = 0.5;
+        // verfiy last point
+        let xDif = Math.abs(pCurrent.x - pLast.x);
+        let yDif = Math.abs(pCurrent.y - pLast.y);
+        if (xDif > 0 && xDif < 10) {
+            radius = xDif * dRef;
+            return radius;
+        }
+        if (yDif > 0 && yDif < 10) {
+            radius = yDif * dRef;
+            return radius;
+        }
+        // verify next point
+        xDif = Math.abs(pCurrent.x - pNext.x);
+        yDif = Math.abs(pCurrent.y - pNext.y);
+        if (xDif > 0 && xDif < 10) {
+            radius = xDif * dRef;
+            return radius;
+        }
+        if (yDif > 0 && yDif < 10) {
+            radius = yDif * dRef;
+            return radius;
+        }
+        // default
+        return radius;
+    }
 }

--- a/open-bpmn.glsp-client/open-bpmn-model/package.json
+++ b/open-bpmn.glsp-client/open-bpmn-model/package.json
@@ -2,21 +2,21 @@
   "name": "@open-bpmn/open-bpmn-model",
   "version": "0.3.0",
   "description": "GLSP model for BPMN 2.0",
-  "license": "(GPL-3.0)",  
+  "license": "(GPL-3.0)",
   "scripts": {
     "prepare": "yarn clean && yarn build && yarn lint",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
     "build": "tsc",
     "lint": "eslint -c ../.eslintrc.js --ext .ts,.tsx ./src",
     "watch": "tsc -w"
   },
   "dependencies": {
     "@eclipse-glsp/client": "^1.0.0"
-  },  
+  },
   "files": [
     "lib",
     "src"
   ],
   "main": "lib/index",
-  "types": "lib/index"  
+  "types": "lib/index"
 }

--- a/open-bpmn.glsp-client/open-bpmn-model/src/bpmn-anchors.ts
+++ b/open-bpmn.glsp-client/open-bpmn-model/src/bpmn-anchors.ts
@@ -13,12 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable } from 'inversify';
 import {
-	ManhattanEdgeRouter,IAnchorComputer,SConnectableElement,PolylineEdgeRouter,
-	Bounds,almostEquals,
-	Point
+    almostEquals,
+    Bounds,
+    IAnchorComputer,
+    ManhattanEdgeRouter,
+    Point,
+    PolylineEdgeRouter,
+    SConnectableElement
 } from '@eclipse-glsp/client';
+import { injectable } from 'inversify';
 
 export const BPMN_ELEMENT_ANCHOR_KIND = 'bpmn-element';
 
@@ -31,8 +35,7 @@ export const BPMN_ELEMENT_ANCHOR_KIND = 'bpmn-element';
  */
 @injectable()
 export class BPMNElementAnchor implements IAnchorComputer {
-
-	static KIND = ManhattanEdgeRouter.KIND + ':' + BPMN_ELEMENT_ANCHOR_KIND;
+    static KIND = ManhattanEdgeRouter.KIND + ':' + BPMN_ELEMENT_ANCHOR_KIND;
 
     get kind(): string {
         return BPMNElementAnchor.KIND;
@@ -50,49 +53,52 @@ export class BPMNElementAnchor implements IAnchorComputer {
             height: b.height + 2 * offset
         };
         if (refPoint.x >= bounds.x && bounds.x + bounds.width >= refPoint.x) {
-            if (refPoint.y < bounds.y + 0.5 * bounds.height)
-            return { x: refPoint.x, y: bounds.y };
-            else
-            return { x: refPoint.x, y: bounds.y + bounds.height };
+            if (refPoint.y < bounds.y + 0.5 * bounds.height) {
+                return { x: refPoint.x, y: bounds.y };
+            } else {
+                return { x: refPoint.x, y: bounds.y + bounds.height };
+            }
         }
         if (refPoint.y >= bounds.y && bounds.y + bounds.height >= refPoint.y) {
-            if (refPoint.x < bounds.x + 0.5 * bounds.width)
-            return { x: bounds.x, y: refPoint.y };
-            else
-            return { x: bounds.x + bounds.width, y: refPoint.y };
+            if (refPoint.x < bounds.x + 0.5 * bounds.width) {
+                return { x: bounds.x, y: refPoint.y };
+            } else {
+                return { x: bounds.x + bounds.width, y: refPoint.y };
+            }
         }
         return Bounds.center(bounds);
     }
 }
 
-
 @injectable()
 export class BPMNPolylineElementAnchor implements IAnchorComputer {
-
-
     get kind(): string {
         return PolylineEdgeRouter.KIND + ':' + BPMN_ELEMENT_ANCHOR_KIND;
     }
 
-    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number ): Point {
+    getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number): Point {
         const bounds = connectable.bounds;
         const c = Bounds.center(bounds);
         const finder = new NearestPointFinder(c, refPoint);
         if (!almostEquals(c.y, refPoint.y)) {
             const xTop = this.getXIntersection(bounds.y, c, refPoint);
-            if (xTop >= bounds.x && xTop <= bounds.x + bounds.width)
+            if (xTop >= bounds.x && xTop <= bounds.x + bounds.width) {
                 finder.addCandidate(xTop, bounds.y - offset);
+            }
             const xBottom = this.getXIntersection(bounds.y + bounds.height, c, refPoint);
-            if (xBottom >= bounds.x && xBottom <= bounds.x + bounds.width)
+            if (xBottom >= bounds.x && xBottom <= bounds.x + bounds.width) {
                 finder.addCandidate(xBottom, bounds.y + bounds.height + offset);
+            }
         }
         if (!almostEquals(c.x, refPoint.x)) {
             const yLeft = this.getYIntersection(bounds.x, c, refPoint);
-            if (yLeft >= bounds.y && yLeft <= bounds.y + bounds.height)
+            if (yLeft >= bounds.y && yLeft <= bounds.y + bounds.height) {
                 finder.addCandidate(bounds.x - offset, yLeft);
+            }
             const yRight = this.getYIntersection(bounds.x + bounds.width, c, refPoint);
-            if (yRight >= bounds.y && yRight <= bounds.y + bounds.height)
+            if (yRight >= bounds.y && yRight <= bounds.y + bounds.height) {
                 finder.addCandidate(bounds.x + bounds.width + offset, yRight);
+            }
         }
         return finder.best;
     }
@@ -106,17 +112,15 @@ export class BPMNPolylineElementAnchor implements IAnchorComputer {
         const t = (xIntersection - centerPoint.x) / (point.x - centerPoint.x);
         return (point.y - centerPoint.y) * t + centerPoint.y;
     }
-
 }
 
 class NearestPointFinder {
     protected currentBest: Point | undefined;
     protected currentDist: number;
 
-    constructor(protected centerPoint: Point, protected refPoint: Point) {
-    }
+    constructor(protected centerPoint: Point, protected refPoint: Point) {}
 
-    addCandidate(x: number, y: number) {
+    addCandidate(x: number, y: number): void {
         const dx = this.refPoint.x - x;
         const dy = this.refPoint.y - y;
         const dist = dx * dx + dy * dy;
@@ -130,10 +134,10 @@ class NearestPointFinder {
     }
 
     get best(): Point {
-        if (this.currentBest === undefined)
+        if (this.currentBest === undefined) {
             return this.centerPoint;
-        else
+        } else {
             return this.currentBest;
+        }
     }
 }
-

--- a/open-bpmn.glsp-client/open-bpmn-properties/package.json
+++ b/open-bpmn.glsp-client/open-bpmn-properties/package.json
@@ -2,7 +2,7 @@
   "name": "@open-bpmn/open-bpmn-properties",
   "version": "0.3.0",
   "description": "GLSP property panel for BPMN 2.0",
-  "license": "(GPL-3.0)",   
+  "license": "(GPL-3.0)",
   "dependencies": {
     "@eclipse-glsp/client": "^1.0.0",
     "@open-bpmn/open-bpmn-model": "0.3.0",
@@ -10,14 +10,14 @@
     "@jsonforms/react": "3.0.0-beta.5",
     "@jsonforms/vanilla-renderers": "3.0.0-beta.5",
     "balloon-css": "^0.5.0"
-  },  
-    "peerDependencies": {
+  },
+  "peerDependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
-  },  
+  },
   "scripts": {
     "prepare": "yarn clean && yarn build && yarn lint",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
     "build": "tsc",
     "lint": "eslint -c ../.eslintrc.js --ext .ts,.tsx ./src",
     "watch": "tsc -w"

--- a/open-bpmn.glsp-client/open-bpmn-properties/src/EventDefinitionRenderer.tsx
+++ b/open-bpmn.glsp-client/open-bpmn-properties/src/EventDefinitionRenderer.tsx
@@ -14,55 +14,41 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 // import React from 'react';
-import * as React from 'react';
+import { rankWith, scopeEndsWith } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import {
-  scopeEndsWith,
-  rankWith
-} from '@jsonforms/core';
+import * as React from 'react';
 /**
  * This custom renderer provides the detail form for BPMN Event Definition lists.
  *
  */
 interface BPMNEventDefinitionProps {
-  value: any;
-  updateValue: (newValue: any) => void;
+    value: any;
+    updateValue: (newValue: any) => void;
 }
 
 interface BPMNEventDefinitionControlProps {
-  data: any;
-  handleChange(path: string, value: any): void;
-  path: string;
+    data: any;
+    handleChange(path: string, value: any): void;
+    path: string;
 }
 
 // eslint-disable-next-line max-len
 const BPMNEventDefinitionsComponent: React.FC<BPMNEventDefinitionProps> = ({ value, updateValue }: any) => (
     <div id='#/properties/conditions' className='eventDefinitions'>
-      
-      <div style={{ cursor: 'pointer', fontSize: '18px' }}>
-      <span
-              onClick={() => updateValue(value)}
-            >
-      Event Definitions 
-      </span> 
-      </div>
+        <div style={{ cursor: 'pointer', fontSize: '18px' }}>
+            <span onClick={() => updateValue(value)}>Event Definitions</span>
+        </div>
     </div>
 );
 
-const BPMNEventDefinitionControl = ({ data, handleChange, path }: BPMNEventDefinitionControlProps) => (
-  <BPMNEventDefinitionsComponent
-    value={data}
-    updateValue={(newValue: number) => handleChange(path, newValue)}
-  />
+const BPMNEventDefinitionControl = ({ data, handleChange, path }: BPMNEventDefinitionControlProps): JSX.Element => (
+    <BPMNEventDefinitionsComponent value={data} updateValue={(newValue: number) => handleChange(path, newValue)} />
 );
 
 /**
  * Export the Custom Renderer and  Tester for EventDefinitions (eventdefinitions)
  */
-export const BPMNEventDefinitionRenderer: any = { 
-  tester: rankWith(7,scopeEndsWith('conditions')), 
-  renderer: withJsonFormsControlProps(BPMNEventDefinitionControl)
+export const BPMNEventDefinitionRenderer: any = {
+    tester: rankWith(7, scopeEndsWith('conditions')),
+    renderer: withJsonFormsControlProps(BPMNEventDefinitionControl)
 };
-
-
-

--- a/open-bpmn.glsp-client/open-bpmn-properties/src/ImixsArrayRenderer.tsx
+++ b/open-bpmn.glsp-client/open-bpmn-properties/src/ImixsArrayRenderer.tsx
@@ -14,135 +14,142 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 // import React from 'react';
-//import * as React from 'react';
-import React, { useMemo } from 'react';
-import range from 'lodash/range';
-import { JsonFormsDispatch } from '@jsonforms/react';
+// import * as React from 'react';
 import {
-  scopeEndsWith,ControlElement,Helpers,
-  rankWith,ArrayControlProps, composePaths, createDefaultValue, findUISchema
+    ArrayControlProps,
+    composePaths,
+    ControlElement,
+    createDefaultValue,
+    findUISchema,
+    Helpers,
+    JsonFormsUISchemaRegistryEntry,
+    rankWith,
+    scopeEndsWith
 } from '@jsonforms/core';
+import { JsonFormsDispatch } from '@jsonforms/react';
 import { VanillaRendererProps } from '@jsonforms/vanilla-renderers';
+import range from 'lodash/range';
+import React, { useMemo } from 'react';
 
-// We rename ''control'' into 'component' 
+export interface BPMNArrayComponentProps extends ArrayControlProps, VanillaRendererProps {
+    uischemas: JsonFormsUISchemaRegistryEntry[];
+    classNames: {
+        [className: string]: string;
+    };
+}
+// We rename ''control'' into 'component'
 const BPMNArrayComponent = ({
-  classNames,
-  data,
-  label,
-  path,
-  schema,
-  addItem,
-  uischema,
-  uischemas,
-  renderers,
-  rootSchema
-}: ArrayControlProps & VanillaRendererProps) => {
-  const childUiSchema = useMemo(
-    () => findUISchema(uischemas, schema, uischema.scope, path, undefined, uischema, rootSchema),
-    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
-  );
-  return (
-    <div className={classNames.wrapper}>
-      <fieldset className={classNames.fieldSet}>
-        <legend>
-          <button
-            className={classNames.button}
-            onClick={addItem(path, createDefaultValue(schema))}
-          >
-            +
-          </button>
-          <label className={'array.label'}>{label}</label>
-        </legend>
-        <div className={classNames.children}>
-          {data ? (
-            range(0, data.length).map(index => {
-              const childPath = composePaths(path, `${index}`);
+    classNames,
+    data,
+    label,
+    path,
+    schema,
+    addItem,
+    uischema,
+    uischemas,
+    renderers,
+    rootSchema
+}: BPMNArrayComponentProps): JSX.Element => {
+    const childUiSchema = useMemo(
+        () => findUISchema(uischemas, schema, uischema.scope, path, undefined, uischema, rootSchema),
+        [uischemas, schema, uischema.scope, path, uischema, rootSchema]
+    );
+    return (
+        <div className={classNames.wrapper}>
+            <fieldset className={classNames.fieldSet}>
+                <legend>
+                    <button className={classNames.button} onClick={addItem(path, createDefaultValue(schema))}>
+                        +
+                    </button>
+                    <label className={'array.label'}>{label}</label>
+                </legend>
+                <div className={classNames.children}>
+                    {data ? (
+                        range(0, data.length).map(index => {
+                            const childPath = composePaths(path, `${index}`);
 
-              return (
-                <JsonFormsDispatch
-                  schema={schema}
-                  uischema={childUiSchema || uischema}
-                  path={childPath}
-                  key={childPath}
-                  renderers={renderers}
-                />
-              );
-            })
-          ) : (
-              <p>No data</p>
-            )}
+                            return (
+                                <JsonFormsDispatch
+                                    schema={schema}
+                                    uischema={childUiSchema || uischema}
+                                    path={childPath}
+                                    key={childPath}
+                                    renderers={renderers}
+                                />
+                            );
+                        })
+                    ) : (
+                        <p>No data</p>
+                    )}
+                </div>
+            </fieldset>
         </div>
-      </fieldset>
-    </div>
-  );
+    );
 };
 
+export interface BPMNArrayControlProps extends ArrayControlProps, VanillaRendererProps {
+    getStyleAsClassName(string: string, ...args: any[]): string;
+    uischemas: JsonFormsUISchemaRegistryEntry[];
+}
 // we rename 'ControlRenderer' into 'Control'
 // eslint-disable-next-line max-len
-const BPMNArrayControl =
-    ({
-        schema,
-        uischema,
-        data,
-        path,
-        rootSchema,
-        uischemas,
-        addItem,
-        getStyle,
-        getStyleAsClassName,
-        removeItems,
-        id,
-        visible,
-        enabled,
-        errors
-    }: ArrayControlProps & VanillaRendererProps) => {
-
-        const controlElement = uischema as ControlElement;
-        const labelDescription = Helpers.createLabelDescriptionFrom(controlElement, schema);
-        const label = labelDescription.show ? labelDescription.text : '';
-        const controlClassName =
-            `control ${(Helpers.convertToValidClassName(controlElement.scope))}`;
-        const fieldSetClassName = getStyleAsClassName('array.layout');
-        const buttonClassName = getStyleAsClassName('array.button');
-        const childrenClassName = getStyleAsClassName('array.children');
-        const classNames: { [className: string]: string } = {
-            wrapper: controlClassName,
-            fieldSet: fieldSetClassName,
-            button: buttonClassName,
-            children: childrenClassName
-        };
-
-        return (
-            <BPMNArrayComponent
-                errors={errors}
-                getStyle={getStyle}
-                getStyleAsClassName={getStyleAsClassName}
-                removeItems={removeItems}
-                classNames={classNames}
-                data={data}
-                label={label}
-                path={path}
-                addItem={addItem}
-                uischemas={uischemas}
-                uischema={uischema}
-                schema={schema}
-                rootSchema={rootSchema}
-                id={id}
-                visible={visible}
-                enabled={enabled}
-            />
-        );
+const BPMNArrayControl = ({
+    schema,
+    uischema,
+    data,
+    path,
+    rootSchema,
+    uischemas,
+    addItem,
+    getStyle,
+    getStyleAsClassName,
+    removeItems,
+    id,
+    visible,
+    enabled,
+    errors
+}: BPMNArrayControlProps): JSX.Element => {
+    const controlElement = uischema as ControlElement;
+    const labelDescription = Helpers.createLabelDescriptionFrom(controlElement, schema);
+    const label = labelDescription.show ? labelDescription.text ?? '' : '';
+    const controlClassName = `control ${Helpers.convertToValidClassName(controlElement.scope)}`;
+    const fieldSetClassName = getStyleAsClassName('array.layout');
+    const buttonClassName = getStyleAsClassName('array.button');
+    const childrenClassName = getStyleAsClassName('array.children');
+    const classNames: { [className: string]: string } = {
+        wrapper: controlClassName,
+        fieldSet: fieldSetClassName,
+        button: buttonClassName,
+        children: childrenClassName
     };
 
+    return (
+        <BPMNArrayComponent
+            errors={errors}
+            getStyle={getStyle}
+            getStyleAsClassName={getStyleAsClassName}
+            removeItems={removeItems}
+            classNames={classNames}
+            data={data}
+            label={label}
+            path={path}
+            addItem={addItem}
+            uischemas={uischemas}
+            uischema={uischema}
+            schema={schema}
+            rootSchema={rootSchema}
+            id={id}
+            visible={visible}
+            enabled={enabled}
+        />
+    );
+};
 
 /**
  * Export the Custom Renderer and  Tester for EventDefinitions (eventdefinitions)
  */
-export const BPMNEventDefinitionRendererPrio: any = { 
-  tester: rankWith(6,scopeEndsWith('conditions')), 
-  renderer: BPMNArrayControl
-  // withJsonFormsControlProps(BPMNArrayControl)
+export const BPMNEventDefinitionRendererPrio: any = {
+    tester: rankWith(6, scopeEndsWith('conditions')),
+    renderer: BPMNArrayControl
+    // withJsonFormsControlProps(BPMNArrayControl)
 };
-
-
-

--- a/open-bpmn.glsp-client/open-bpmn-properties/src/bpmn-property-panel.tsx
+++ b/open-bpmn.glsp-client/open-bpmn-properties/src/bpmn-property-panel.tsx
@@ -13,300 +13,289 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, postConstruct } from 'inversify';
 import {
-	AbstractUIExtension,
-	Action,
-	EnableDefaultToolsAction,
-	SetUIExtensionVisibilityAction,
-	ActionDispatcher,
-	EnableToolsAction,
-	EditorContextService,
-	EditModeListener,
-	TYPES,
-	SModelRoot, hasArguments
+    AbstractUIExtension,
+    Action,
+    ActionDispatcher,
+    EditModeListener,
+    EditorContextService,
+    EnableDefaultToolsAction,
+    EnableToolsAction,
+    hasArguments,
+    SetUIExtensionVisibilityAction,
+    SModelRoot,
+    TYPES
 } from '@eclipse-glsp/client';
+import { inject, injectable, postConstruct } from 'inversify';
 import { codiconCSSClasses } from 'sprotty/lib/utils/codicon';
 
-import {
-	SelectionListener,
-	SelectionService
-} from '@eclipse-glsp/client/lib/features/select/selection-service';
+import { SelectionListener, SelectionService } from '@eclipse-glsp/client/lib/features/select/selection-service';
 
 import { isBPMNNode } from '@open-bpmn/open-bpmn-model';
 
 // Import Instruction sReact and JsonForms
+import { JsonForms } from '@jsonforms/react';
+import { vanillaCells, vanillaRenderers } from '@jsonforms/vanilla-renderers';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { JsonForms } from '@jsonforms/react';
-import {
-	vanillaCells,
-	vanillaRenderers
-} from '@jsonforms/vanilla-renderers';
 
-//import RatingControl from './RatingControl';
-//import ratingControlTester from './ratingControlTester';
-//import {BPMNEventDefinitionRenderer} from './EventDefinitionRenderer';
+// import RatingControl from './RatingControl';
+// import ratingControlTester from './ratingControlTester';
+// import {BPMNEventDefinitionRenderer} from './EventDefinitionRenderer';
 
 @injectable()
 export class EnableBPMNPropertyPanelAction implements Action {
-	static readonly KIND = 'enableBPMNPropertyPanel';
-	readonly kind = EnableBPMNPropertyPanelAction.KIND;
+    static readonly KIND = 'enableBPMNPropertyPanel';
+    readonly kind = EnableBPMNPropertyPanelAction.KIND;
 }
 
 @injectable()
 export class BPMNPropertyPanel extends AbstractUIExtension implements EditModeListener, SelectionListener {
-	static readonly ID = 'bpmn-property-panel';
+    static readonly ID = 'bpmn-property-panel';
 
-	@inject(TYPES.IActionDispatcher)
-	protected readonly actionDispatcher: ActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected readonly actionDispatcher: ActionDispatcher;
 
-	@inject(EditorContextService)
-	protected readonly editorContext: EditorContextService;
+    @inject(EditorContextService)
+    protected readonly editorContext: EditorContextService;
 
-	@inject(SelectionService)
-	protected selectionService: SelectionService;
+    @inject(SelectionService)
+    protected selectionService: SelectionService;
 
-	protected bodyDiv: HTMLElement;
-	modelRootId: string;
-	selectedElementId: string;
-	initForm: boolean;
-	headerTitle: HTMLElement;
+    protected bodyDiv: HTMLElement;
+    modelRootId: string;
+    selectedElementId: string;
+    initForm: boolean;
+    headerTitle: HTMLElement;
 
-	@postConstruct()
-	postConstruct(): void {
-		this.editorContext.register(this);
-		this.selectionService.register(this);
-	}
+    @postConstruct()
+    postConstruct(): void {
+        this.editorContext.register(this);
+        this.selectionService.register(this);
+    }
 
-	id(): string {
-		return BPMNPropertyPanel.ID;
-	}
-	containerClass(): string {
-		return BPMNPropertyPanel.ID;
-	}
+    id(): string {
+        return BPMNPropertyPanel.ID;
+    }
+    containerClass(): string {
+        return BPMNPropertyPanel.ID;
+    }
 
-	override initialize(): boolean {
-		return super.initialize();
-	}
+    override initialize(): boolean {
+        return super.initialize();
+    }
 
-	/*
-	 * Initalize the elemnts of property panel
-	 */
-	protected initializeContents(_containerElement: HTMLElement): void {
-		this.createHeader();
-		this.createBody();
-	}
+    /*
+     * Initalize the elemnts of property panel
+     */
+    protected initializeContents(_containerElement: HTMLElement): void {
+        this.createHeader();
+        this.createBody();
+    }
 
-	protected override onBeforeShow(_containerElement: HTMLElement, root: Readonly<SModelRoot>): void {
-		this.modelRootId = root.id;
-	}
+    protected override onBeforeShow(_containerElement: HTMLElement, root: Readonly<SModelRoot>): void {
+        this.modelRootId = root.id;
+    }
 
-	protected createHeader(): void {
-		const headerCompartment = document.createElement('div');
-		headerCompartment.classList.add('bpmn-property-header');
-		headerCompartment.append(this.createHeaderTitle());
-		headerCompartment.appendChild(this.createHeaderTools());
-		this.containerElement.appendChild(headerCompartment);
-	}
+    protected createHeader(): void {
+        const headerCompartment = document.createElement('div');
+        headerCompartment.classList.add('bpmn-property-header');
+        headerCompartment.append(this.createHeaderTitle());
+        headerCompartment.appendChild(this.createHeaderTools());
+        this.containerElement.appendChild(headerCompartment);
+    }
 
-	protected createBody(): void {
-		const bodyDiv = document.createElement('div');
-		// , 'jsonforms-property-view'
-		bodyDiv.classList.add('bpmn-properties-body');
-		this.containerElement.appendChild(bodyDiv);
-		this.bodyDiv = bodyDiv;
-	}
+    protected createBody(): void {
+        const bodyDiv = document.createElement('div');
+        // , 'jsonforms-property-view'
+        bodyDiv.classList.add('bpmn-properties-body');
+        this.containerElement.appendChild(bodyDiv);
+        this.bodyDiv = bodyDiv;
+    }
 
-	protected createHeaderTitle(): HTMLElement {
-		const header = document.createElement('div');
-		header.classList.add('header-icon');
-		header.appendChild(createIcon('extensions'));
-		this.headerTitle = document.createElement('span');
-		header.appendChild(this.headerTitle);
-		this.headerTitle.textContent = 'BPMN Properties';
-		return header;
-	}
+    protected createHeaderTitle(): HTMLElement {
+        const header = document.createElement('div');
+        header.classList.add('header-icon');
+        header.appendChild(createIcon('extensions'));
+        this.headerTitle = document.createElement('span');
+        header.appendChild(this.headerTitle);
+        this.headerTitle.textContent = 'BPMN Properties';
+        return header;
+    }
 
-	/*
-	 * This method creads the header tool buttons to controle the size of the panel
-	 * Icons can be found here:
-	 * https://microsoft.github.io/vscode-codicons/dist/codicon.html
-	 */
-	private createHeaderTools(): HTMLElement {
-		const headerTools = document.createElement('div');
-		headerTools.classList.add('header-tools');
+    /*
+     * This method creads the header tool buttons to controle the size of the panel
+     * Icons can be found here:
+     * https://microsoft.github.io/vscode-codicons/dist/codicon.html
+     */
+    private createHeaderTools(): HTMLElement {
+        const headerTools = document.createElement('div');
+        headerTools.classList.add('header-tools');
 
-		const hideToolButton = createIcon('chrome-minimize');
-		hideToolButton.title = 'Hide Property Panel';
-		hideToolButton.onclick = this.onClickResizePanel(hideToolButton, 'TOOL_COMMAND_HIDE');
-		headerTools.appendChild(hideToolButton);
+        const hideToolButton = createIcon('chrome-minimize');
+        hideToolButton.title = 'Hide Property Panel';
+        hideToolButton.onclick = this.onClickResizePanel(hideToolButton, 'TOOL_COMMAND_HIDE');
+        headerTools.appendChild(hideToolButton);
 
-		const minimizeToolButton = createIcon('chevron-down');
-		minimizeToolButton.title = 'Minimize Property Panel';
-		minimizeToolButton.onclick = this.onClickResizePanel(minimizeToolButton, 'TOOL_COMMAND_MINIMIZE');
-		headerTools.appendChild(minimizeToolButton);
+        const minimizeToolButton = createIcon('chevron-down');
+        minimizeToolButton.title = 'Minimize Property Panel';
+        minimizeToolButton.onclick = this.onClickResizePanel(minimizeToolButton, 'TOOL_COMMAND_MINIMIZE');
+        headerTools.appendChild(minimizeToolButton);
 
-		const maximizeToolButton = createIcon('chevron-up');
-		maximizeToolButton.title = 'Maximize Property Panel';
-		maximizeToolButton.onclick = this.onClickResizePanel(maximizeToolButton, 'TOOL_COMMAND_MAXIMIZE');
-		headerTools.appendChild(maximizeToolButton);
+        const maximizeToolButton = createIcon('chevron-up');
+        maximizeToolButton.title = 'Maximize Property Panel';
+        maximizeToolButton.onclick = this.onClickResizePanel(maximizeToolButton, 'TOOL_COMMAND_MAXIMIZE');
+        headerTools.appendChild(maximizeToolButton);
 
-		return headerTools;
-	}
+        return headerTools;
+    }
 
-	protected onClickResizePanel(button: HTMLElement, toolId?: string) {
-		return (_ev: MouseEvent) => {
-			if (!this.editorContext.isReadonly) {
-				const action = toolId ? EnableToolsAction.create([toolId]) : EnableDefaultToolsAction.create();
-				this.actionDispatcher.dispatch(action);
-				if (toolId === 'TOOL_COMMAND_MINIMIZE') {
-					this.containerElement.style.height = '33.333%';
-				}
-				if (toolId === 'TOOL_COMMAND_MAXIMIZE') {
-					this.containerElement.style.height = '50%';
-				}
-				if (toolId === 'TOOL_COMMAND_HIDE') {
-					this.containerElement.style.height = '25px';
-				}
-				// restore the defautl actions in the diagram panel (like move elements)
-				this.actionDispatcher.dispatch(EnableDefaultToolsAction.create());
-			}
-		};
-	}
+    protected onClickResizePanel(button: HTMLElement, toolId?: string) {
+        return (_ev: MouseEvent) => {
+            if (!this.editorContext.isReadonly) {
+                const action = toolId ? EnableToolsAction.create([toolId]) : EnableDefaultToolsAction.create();
+                this.actionDispatcher.dispatch(action);
+                if (toolId === 'TOOL_COMMAND_MINIMIZE') {
+                    this.containerElement.style.height = '33.333%';
+                }
+                if (toolId === 'TOOL_COMMAND_MAXIMIZE') {
+                    this.containerElement.style.height = '50%';
+                }
+                if (toolId === 'TOOL_COMMAND_HIDE') {
+                    this.containerElement.style.height = '25px';
+                }
+                // restore the defautl actions in the diagram panel (like move elements)
+                this.actionDispatcher.dispatch(EnableDefaultToolsAction.create());
+            }
+        };
+    }
 
-	editModeChanged(_oldValue: string, _newValue: string): void {
-		// eslint-disable-next-line max-len
-		this.actionDispatcher.dispatch(SetUIExtensionVisibilityAction.create({ extensionId: BPMNPropertyPanel.ID, visible: !this.editorContext.isReadonly }));
-	}
+    editModeChanged(_oldValue: string, _newValue: string): void {
+        // eslint-disable-next-line max-len
+        this.actionDispatcher.dispatch(
+            SetUIExtensionVisibilityAction.create({ extensionId: BPMNPropertyPanel.ID, visible: !this.editorContext.isReadonly })
+        );
+    }
 
-	/*
-	 * This mehtod reacts on the selection of a BPMN element
-	 * and updates the property panel input fields
-	 */
-	selectionChanged(root: Readonly<SModelRoot>, selectedElements: string[]): void {
-		// first we need to verify if a Symbol/BPMNLabel combination was selected.
-		// In this case we are only interested in the BPMNFlowElement and not in the label
-		if (selectedElements.length > 1) {
-			const filteredArr = selectedElements.filter(val => !val.endsWith('_bpmnlabel'));
-			selectedElements = filteredArr;
-		}
+    /*
+     * This mehtod reacts on the selection of a BPMN element
+     * and updates the property panel input fields
+     */
+    selectionChanged(root: Readonly<SModelRoot>, selectedElements: string[]): void {
+        // first we need to verify if a Symbol/BPMNLabel combination was selected.
+        // In this case we are only interested in the BPMNFlowElement and not in the label
+        if (selectedElements.length > 1) {
+            const filteredArr = selectedElements.filter(val => !val.endsWith('_bpmnlabel'));
+            selectedElements = filteredArr;
+        }
 
-		// Check if we now have exactly one elemnt selected. Only in this case we show
-		// a property panel.
-		if (selectedElements.length === 1) {
-			const element = root.index.getById(selectedElements[0]);
-			if (element) {
-				// did we have a change?
-				// avoid message loop...
-				if (element.id === this.selectedElementId) {
-					// skip this event!
-					return;
-				}
-				// set new selectionId
-				this.selectedElementId = element.id;
-				console.log('======== > setup new property panel - selectionID=' + element.id);
-				// because the jsonFomrs send a onchange event after init we mark this state here
-				this.initForm = true;
-				// update header
-				// this.header.insertAdjacentText('beforeend',element.type);
-				this.headerTitle.textContent = element.type;
+        // Check if we now have exactly one elemnt selected. Only in this case we show
+        // a property panel.
+        if (selectedElements.length === 1) {
+            const element = root.index.getById(selectedElements[0]);
+            if (element) {
+                // did we have a change?
+                // avoid message loop...
+                if (element.id === this.selectedElementId) {
+                    // skip this event!
+                    return;
+                }
+                // set new selectionId
+                this.selectedElementId = element.id;
+                console.log('======== > setup new property panel - selectionID=' + element.id);
+                // because the jsonFomrs send a onchange event after init we mark this state here
+                this.initForm = true;
+                // update header
+                // this.header.insertAdjacentText('beforeend',element.type);
+                this.headerTitle.textContent = element.type;
 
-				// Build a generic JSONForms Property panel
-				if (isBPMNNode(element)) {
-					// BPMN Node selected, collect JSONForms schemata....
-					let bpmnPropertiesData;
-					let bpmnPropertiesSchema;
-					let bpmnPropertiesUISchema;
-					if (hasArguments(element)) {
-						// parse the jsonForms schema details
-						bpmnPropertiesData = JSON.parse(element.args.JSONFormsData + '');
-						bpmnPropertiesSchema = JSON.parse(element.args.JSONFormsSchema + '');
-						bpmnPropertiesUISchema = JSON.parse(element.args.JSONFormsUISchema + '');
-					}
+                // Build a generic JSONForms Property panel
+                if (isBPMNNode(element)) {
+                    // BPMN Node selected, collect JSONForms schemata....
+                    let bpmnPropertiesData;
+                    let bpmnPropertiesSchema;
+                    let bpmnPropertiesUISchema;
+                    if (hasArguments(element)) {
+                        // parse the jsonForms schema details
+                        bpmnPropertiesData = JSON.parse(element.args.JSONFormsData + '');
+                        bpmnPropertiesSchema = JSON.parse(element.args.JSONFormsSchema + '');
+                        bpmnPropertiesUISchema = JSON.parse(element.args.JSONFormsUISchema + '');
+                    }
 
-					// list of renderers declared outside the App component
-					const bpmnRenderers = [
-						...vanillaRenderers,
-						//register custom renderers 
-						//BPMNEventDefinitionRenderer,
-						//{ tester: ratingControlTester, renderer: RatingControl }
-					];
+                    // list of renderers declared outside the App component
+                    const bpmnRenderers = [
+                        ...vanillaRenderers
+                        // register custom renderers
+                        // BPMNEventDefinitionRenderer,
+                        // { tester: ratingControlTester, renderer: RatingControl }
+                    ];
 
+                    // render JSONForm // vanillaRenderers
+                    ReactDOM.render(
+                        <JsonForms
+                            data={bpmnPropertiesData}
+                            schema={bpmnPropertiesSchema}
+                            uischema={bpmnPropertiesUISchema}
+                            cells={vanillaCells}
+                            renderers={bpmnRenderers}
+                            onChange={({ errors, data }) => this.setState({ data })}
+                        />,
+                        this.bodyDiv
+                    );
+                }
+            } else {
+                // element not defined!
+                this.selectedElementId = '';
+                this.headerTitle.textContent = 'BPMN Properties';
+            }
+        } else {
+            // no single element selected!
+            this.selectedElementId = '';
+            if (this.bodyDiv) {
+                this.headerTitle.textContent = 'BPMN Properties';
+                if (!this.selectionService.hasSelectedElements()) {
+                    // show an empty pane (or later the process panel)
+                    if (this.bodyDiv) {
+                        ReactDOM.render(<React.Fragment>Please select an element </React.Fragment>, this.bodyDiv);
+                    }
+                } else {
+                    // multi selection - we can not show a property panel
+                    if (this.bodyDiv) {
+                        ReactDOM.render(<React.Fragment>Please select a single element </React.Fragment>, this.bodyDiv);
+                    }
+                }
+            }
+        }
+    }
 
-
-					// render JSONForm // vanillaRenderers
-					ReactDOM.render(
-						<JsonForms
-							data={bpmnPropertiesData}
-							schema={bpmnPropertiesSchema}
-							uischema={bpmnPropertiesUISchema}
-							cells={vanillaCells}
-							renderers={bpmnRenderers}
-							onChange={({ errors, data }) => this.setState({ data })}
-						/>,
-						this.bodyDiv
-					);
-				}
-			} else {
-				// element not defined!
-				this.selectedElementId = '';
-				this.headerTitle.textContent = 'BPMN Properties';
-			}
-		} else {
-			// no single element selected!
-			this.selectedElementId = '';
-			if (this.bodyDiv) {
-				this.headerTitle.textContent = 'BPMN Properties';
-				if (!this.selectionService.hasSelectedElements()) {
-					// show an empty pane (or later the process panel)
-					if (this.bodyDiv) {
-						ReactDOM.render(
-							<React.Fragment>Please select an element </React.Fragment>,
-							this.bodyDiv
-						);
-					}
-				} else {
-					// multi selection - we can not show a property panel
-					if (this.bodyDiv) {
-						ReactDOM.render(
-							<React.Fragment>Please select a single element </React.Fragment>,
-							this.bodyDiv
-						);
-					}
-				}
-			}
-		}
-	}
-
-	/*
-	 * This method is responsible to send the new data in a
-	 * ApplyEditOperation Action to the server....
-	 */
-	setState(_newData: any): void {
-		if (this.initForm) {
-			// we ignore the first onChange event
-			// see https://jsonforms.io/docs/integrations/react/#onchange
-			this.initForm = false;
-			return;
-		}
-		const newJsonData = JSON.stringify(_newData.data);
-		const action = new BPMNApplyPropertiesUpdateOperation(this.selectedElementId, newJsonData);
-		this.actionDispatcher.dispatch(action);
-	}
+    /*
+     * This method is responsible to send the new data in a
+     * ApplyEditOperation Action to the server....
+     */
+    setState(_newData: any): void {
+        if (this.initForm) {
+            // we ignore the first onChange event
+            // see https://jsonforms.io/docs/integrations/react/#onchange
+            this.initForm = false;
+            return;
+        }
+        const newJsonData = JSON.stringify(_newData.data);
+        const action = new BPMNApplyPropertiesUpdateOperation(this.selectedElementId, newJsonData);
+        this.actionDispatcher.dispatch(action);
+    }
 }
 
 /**
  * This action is send after a property change to the backend providing the ID and the new value
  */
 export class BPMNApplyPropertiesUpdateOperation implements Action {
-	static readonly KIND = 'applyBPMNPropertiesUpdate';
-	readonly kind = BPMNApplyPropertiesUpdateOperation.KIND;
-	constructor(readonly id: string, readonly jsonData: string) { }
+    static readonly KIND = 'applyBPMNPropertiesUpdate';
+    readonly kind = BPMNApplyPropertiesUpdateOperation.KIND;
+    constructor(readonly id: string, readonly jsonData: string) {}
 }
 
 export function createIcon(codiconId: string): HTMLElement {
-	const icon = document.createElement('i');
-	icon.classList.add(...codiconCSSClasses(codiconId));
-	return icon;
+    const icon = document.createElement('i');
+    icon.classList.add(...codiconCSSClasses(codiconId));
+    return icon;
 }

--- a/open-bpmn.glsp-client/open-bpmn-properties/tsconfig.json
+++ b/open-bpmn.glsp-client/open-bpmn-properties/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "lib",
     "baseUrl": ".",
     "jsx": "react",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "esModuleInterop": true
   },
   "include": ["src"]
 }

--- a/open-bpmn.glsp-client/open-bpmn-theia/package.json
+++ b/open-bpmn.glsp-client/open-bpmn-theia/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "prepare": "yarn  clean && yarn build && yarn lint",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
     "build": "tsc",
     "lint": "eslint -c ../.eslintrc.js --ext .ts,.tsx ./src",
     "watch": "tsc -w"


### PR DESCRIPTION
- Add tsconfig.tsbuildinfo to gitingore and ensure that is removed when a `clean` script is executed. This file was introduced with the ugprade to TS 4.5 (implicitly with glsp-config 1.0.0)
- Adds `esModuleInterop` flag to `open-bpmn-properties` tsconfig
- Fix type warnings in `ImixsArrayRenderer` by introducing composite type interfaces  (and undefined checking).
-  Autoformat files that showed linter warnings  (e.g. `bpmn-anchor.ts`) with `prettier` to get rid of linter warnings
- Adapt `webpack.config.js` to ignore source map loader warnings.